### PR TITLE
Adding simple HTML test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,7 +60,7 @@ module.exports = function (config) {
 
     html2JsPreprocessor: {
       // strip this from the file path
-      stripPrefix: 'src/test/',
+      stripPrefix: 'test/',
     },
   });
 };

--- a/src/test/basic_test.expected.html
+++ b/src/test/basic_test.expected.html
@@ -1,0 +1,1 @@
+<p> This is a <mark>trivial test of</mark> the marking logic. </p>

--- a/src/test/basic_test.html
+++ b/src/test/basic_test.html
@@ -1,0 +1,1 @@
+<p> This is a trivial test of the marking logic. </p>

--- a/src/test/text-fragment-utils-test.js
+++ b/src/test/text-fragment-utils-test.js
@@ -5,4 +5,16 @@ describe('TextFragmentUtils', function () {
     const directives = utils.getFragmentDirectives('#foo:~:text=bar&text=baz');
     expect(directives.text).toEqual(['bar', 'baz']);
   });
+  
+  it('marks simple matching text', function () {
+    console.log(__html__);
+    
+    document.body.innerHTML = __html__['basic_test.html'];
+    
+    var directive = { text: [{textStart: 'trivial test of'}]};
+    utils.processFragmentDirectives(directive);
+    
+    expect(document.body.innerHTML)
+        .toEqual(__html__['basic_test.expected.html']);
+  });
 });


### PR DESCRIPTION
This adds a simple HTML test of the marking logic in its most basic case (a straightforward text match inside a <p> tag). It should be useful as a model for writing additional HTML tests.