### PR TITLE
Reflect `fragmentDirective` location change

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ From unpkg:
 
 ```html
 <script type="module>
-  if (!('fragmentDirective' in Location.prototype)) {
+  if (!('fragmentDirective' in Location.prototype) &&
+      !('fragmentDirective' in document)) {
     import('https://unpkg.com/text-fragments-polyfill');
   }
 </script>
@@ -48,7 +49,8 @@ From unpkg:
 
 ```js
 // Only load the polyfill in browsers that need it.
-if (!('fragmentDirective' in Location.prototype)) {
+if (!('fragmentDirective' in Location.prototype) &&
+    !('fragmentDirective' in document)) {
   import('text-fragments.js');
 }
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,7 +16,8 @@
     <script type="module">
       location.hash =
         ':~:text=This%20domain,examples&text=in%20literature&text=More%20information...';
-      if (!('fragmentDirective' in Location.prototype)) {
+      if (!('fragmentDirective' in Location.prototype) &&
+          !('fragmentDirective' in document)) {
         import('../src/text-fragments.js');
       }
     </script>

--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -26,7 +26,7 @@ import * as utils from './text-fragment-utils.js';
   }
 
   // Pass feature detection (https://web.dev/text-fragments/#feature-detection)
-  Location.prototype.fragmentDirective = {};
+  document.fragmentDirective = {};
 
   const init = () => {
     const fragmentDirectives = utils.getFragmentDirectives(hash);


### PR DESCRIPTION
- Exclusively support the new location in the polyfill itself.
- Support the legacy location in the demo and the usage notes. Eventually, these can be removed, too (opened a [reminder issue](https://github.com/GoogleChromeLabs/text-fragments-polyfill/issues/9) to keep this on the radar). 