### PR TITLE
Add boundary point and string normalization utils

### DIFF
--- a/src/test/boundary-points.html
+++ b/src/test/boundary-points.html
@@ -1,0 +1,5 @@
+<p id="root">
+  thîs téxt
+  <i>hàs <b>a</b></i>
+  <span> lot of </span> パ, き゚, く゚, け゚, プ stüff gøing on
+</p>

--- a/src/test/text-fragment-utils-test.js
+++ b/src/test/text-fragment-utils-test.js
@@ -32,7 +32,7 @@ describe('TextFragmentUtils', function () {
     );
   });
 
-  it('works with complexe layouts', function () {
+  it('works with complex layouts', function () {
     document.body.innerHTML = window.__html__['complicated-layout.html'];
     const directives = utils.getFragmentDirectives(
       '#:~:text=is%20a%20test,And%20another%20on',
@@ -77,5 +77,69 @@ describe('TextFragmentUtils', function () {
     range.setEnd(document.getElementById('e').nextSibling, 6);
     const marks = utils.forTesting.markRange(range);
     expect(marksArrayToString(marks)).toEqual('elaborate fancy div');
+  });
+
+  it('can normalize text', function () {
+    // Dict mapping inputs to expected outputs.
+    const testCases = {
+      '': '',
+      ' foo123 ': ' foo123 ',
+      // Various whitespace is collapsed
+      '\n Kirby\t Puckett   ': ' Kirby Puckett ',
+      // Latin accent characters are removed
+      ñîçè: 'nice',
+      // Some Japanese characters like パ can be rendered with 1 or 2 code
+      // points; the normalized version will always use two.
+      '『パープル・レイン』': '『ハ\u309Aーフ\u309Aル・レイン』',
+      // Chinese and Russian don't use diacritics and are unchanged.
+      紫雨: '紫雨',
+      'Кирилл Капризов': 'Кирилл Капризов',
+    };
+
+    for (const input of Object.getOwnPropertyNames(testCases)) {
+      expect(utils.forTesting.normalizeString(input)).toEqual(testCases[input]);
+    }
+  });
+
+  it('can find boundary points', function () {
+    document.body.innerHTML = __html__['boundary-points.html'];
+    const rootNode = document.getElementById('root');
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const textContent = utils.forTesting.normalizeString(rootNode.textContent);
+    const allTextNodes = [];
+    let textNode = walker.nextNode();
+    while (textNode != null) {
+      allTextNodes.push(textNode);
+      textNode = walker.nextNode();
+    }
+
+    // Test cases are substrings of the normalized text content of the document.
+    // The goal in each case is to produce a range pointing to the substring.
+    const testCases = [
+      ' this text has a',
+      ' has a lot of ハ\u309A,',
+      ' フ\u309A stuff gøing on ',
+    ];
+
+    for (const input of testCases) {
+      const startIndex = textContent.search(input);
+      expect(startIndex).not.toEqual(-1);
+      const endIndex = startIndex + input.length;
+
+      const start = utils.forTesting.getBoundaryPointAtIndex(
+        startIndex,
+        allTextNodes,
+        /* isEnd= */ false,
+      );
+      const end = utils.forTesting.getBoundaryPointAtIndex(
+        endIndex,
+        allTextNodes,
+        /* isEnd= */ true,
+      );
+      const range = document.createRange();
+      range.setStart(start[0], start[1]);
+      range.setEnd(end[0], end[1]);
+      expect(utils.forTesting.normalizeString(range.toString())).toEqual(input);
+    }
   });
 });

--- a/src/test/text-fragment-utils-test.js
+++ b/src/test/text-fragment-utils-test.js
@@ -137,8 +137,8 @@ describe('TextFragmentUtils', function () {
         /* isEnd= */ true,
       );
       const range = document.createRange();
-      range.setStart(start[0], start[1]);
-      range.setEnd(end[0], end[1]);
+      range.setStart(start.node, start.offset);
+      range.setEnd(end.node, end.offset);
       expect(utils.forTesting.normalizeString(range.toString())).toEqual(input);
     }
   });

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -537,6 +537,13 @@ const findRangeFromNodeList = (query, range, textNodes) => {
 };
 
 /**
+ * Provides the data needed for calling setStart/setEnd on a Range.
+ * @typedef {Object} BoundaryPoint
+ * @property {Node} node
+ * @property {Number} offset
+ */
+
+/**
  * Generates a boundary point pointing to the given text position.
  * @param {Number} index - the text offset indicating the start/end of a
  *     substring of the concatenated, normalized text in |textNodes|
@@ -544,8 +551,8 @@ const findRangeFromNodeList = (query, range, textNodes) => {
  *     space
  * @param {bool} isEnd - indicates whether the offset is the start or end of the
  *     substring
- * @return {[Node, Number]} - a boundary point suitable for setting as the start
- *     or end of a Range, or an empty tuple if it couldn't be computed.
+ * @return {BoundaryPoint} - a boundary point suitable for setting as the start
+ *     or end of a Range, or undefined if it couldn't be computed.
  */
 const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
   let counted = 0;
@@ -584,7 +591,7 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
         denormalizedOffset <= node.data.length
       ) {
         if (candidateSubstring.length === targetSubstring.length)
-          return [node, denormalizedOffset];
+          return { node: node, offset: denormalizedOffset };
 
         denormalizedOffset += direction;
 
@@ -611,7 +618,7 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
       normalizedData = nextNormalizedData;
     }
   }
-  return [];
+  return undefined;
 };
 
 /**
@@ -639,7 +646,7 @@ const normalizeString = (str) => {
   // consecutive whitespace characters into a standard " ", and strip out
   // anything in the Unicode U+0300..U+036F (Combining Diacritical Marks) range.
   // This may change the length of the string.
-  return str
+  return (str || '')
     .normalize('NFKD')
     .replace(/\s+/g, ' ')
     .replace(/[\u0300-\u036f]/g, '');

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -539,16 +539,78 @@ const findRangeFromNodeList = (query, range, textNodes) => {
 /**
  * Generates a boundary point pointing to the given text position.
  * @param {Number} index - the text offset indicating the start/end of a
- *     substring of the concatenated text of |textNodes|
+ *     substring of the concatenated, normalized text in |textNodes|
  * @param {Node[]} textNodes - the text Nodes whose contents make up the search
  *     space
  * @param {bool} isEnd - indicates whether the offset is the start or end of the
  *     substring
  * @return {[Node, Number]} - a boundary point suitable for setting as the start
- *     or end of a Range
+ *     or end of a Range, or an empty tuple if it couldn't be computed.
  */
 const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
-  // Iterate over lengths
+  let counted = 0;
+  let normalizedData;
+  for (let i = 0; i < textNodes.length; i++) {
+    const node = textNodes[i];
+    if (!normalizedData) normalizedData = normalizeString(node.data);
+    let nodeEnd = counted + normalizedData.length;
+    if (isEnd) nodeEnd += 1;
+    if (nodeEnd > index) {
+      // |index| falls within this node, but we need to turn the offset in the
+      // normalized data into an offset in the real node data.
+      const normalizedOffset = index - counted;
+      let denormalizedOffset = Math.min(index - counted, node.data.length);
+
+      // Walk through the string until denormalizedOffset produces a substring
+      // that corresponds to the target from the normalized data.
+      const targetSubstring = isEnd
+        ? normalizedData.substring(0, normalizedOffset)
+        : normalizedData.substring(normalizedOffset);
+
+      let candidateSubstring = isEnd
+        ? normalizeString(node.data.substring(0, denormalizedOffset))
+        : normalizeString(node.data.substring(denormalizedOffset));
+
+      // We will either lengthen or shrink the candidate string to approach the
+      // length of the target string. If we're looking for the start, adding 1
+      // makes the candidate shorter; if we're looking for the end, it makes the
+      // candidate longer.
+      const direction =
+        (isEnd ? -1 : 1) *
+        (targetSubstring.length > candidateSubstring.length ? -1 : 1);
+
+      while (
+        denormalizedOffset >= 0 &&
+        denormalizedOffset <= node.data.length
+      ) {
+        if (candidateSubstring.length === targetSubstring.length)
+          return [node, denormalizedOffset];
+
+        denormalizedOffset += direction;
+
+        candidateSubstring = isEnd
+          ? normalizeString(node.data.substring(0, denormalizedOffset))
+          : normalizeString(node.data.substring(denormalizedOffset));
+      }
+    }
+    counted += normalizedData.length;
+
+    if (i + 1 < textNodes.length) {
+      // Edge case: if this node ends with a whitespace character and the next
+      // node starts with one, they'll be double-counted relative to the
+      // normalized version. Subtract 1 from |counted| to compensate.
+      const nextNormalizedData = normalizeString(textNodes[i + 1].data);
+      if (
+        normalizedData.slice(-1) === ' ' &&
+        nextNormalizedData.slice(0, 1) === ' '
+      ) {
+        counted -= 1;
+      }
+      // Since we already normalized the next node's data, hold on to it for the
+      // next iteration.
+      normalizedData = nextNormalizedData;
+    }
+  }
   return [];
 };
 
@@ -566,12 +628,30 @@ const isWordBounded = (text, startPos, length) => {
   // Where boundary chars are whitespace/punctuation.
 };
 
+/**
+ * @param {String} str - a string to be normalized
+ * @return {String} - a normalized version of |str| with all consecutive
+ *     whitespace chars converted to a single ' ' and all diacriticals removed
+ *     (e.g., 'é' -> 'e').
+ */
+const normalizeString = (str) => {
+  // First, decompose any characters with diacriticals. Then, turn all
+  // consecutive whitespace characters into a standard " ", and strip out
+  // anything in the Unicode U+0300..U+036F (Combining Diacritical Marks) range.
+  // This may change the length of the string.
+  return str
+    .normalize('NFKD')
+    .replace(/\s+/g, ' ')
+    .replace(/[\u0300-\u036f]/g, '');
+};
+
 export const forTesting = {
   markRange: markRange,
   findTextInRange: findTextInRange,
   findRangeFromNodeList: findRangeFromNodeList,
   getBoundaryPointAtIndex: getBoundaryPointAtIndex,
   isWordBounded: isWordBounded,
+  normalizeString: normalizeString,
 };
 
 // Allow importing module from closure-compiler projects that haven't migrated


### PR DESCRIPTION
This pull will add two needed utils: one which normalizes a string for comparisons, and one which helps us find the boundary points of a Range in the _real DOM_ based on an index in the _normalized_ text.