### PR TITLE
Changing tooling to use Google Style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,25 @@
         "readdirp": "~3.4.0"
       }
     },
+    "clang-format": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.4.0.tgz",
+      "integrity": "sha512-NrdyUnHJOGvMa60vbWk7GJTvOdhibj3uK5C0FlwdNG4301OUvqEJTFce9I9x8qw2odBbIVrJ+9xbsFS3a4FbDA==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "glob": "^7.0.0",
+        "resolve": "^1.1.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "demo"
   ],
   "devDependencies": {
+    "clang-format": "^1.4.0",
     "eslint": "^7.5.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^6.11.0",
@@ -31,7 +32,7 @@
   "scripts": {
     "start": "npx http-server",
     "clean": "shx rm -rf dist",
-    "fix": "npx prettier --write .",
+    "fix": "npx clang-format --style=Google -i ./src/*.js ./tools/*.js && npx prettier --write **/*.json **/*.html",
     "prepare": "npm run clean && npm run fix && npm run lint && npx rollup src/text-fragments.js --dir dist -p 'terser'",
     "lint": "npx eslint . --ext .js,.mjs --fix --ignore-pattern dist/",
     "test": "./node_modules/karma/bin/karma start --single-run"

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -28,46 +28,20 @@ const FRAGMENT_DIRECTIVES = ['text'];
 // block element. Source for the list:
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#Elements
 const BLOCK_ELEMENTS = [
-  'ADDRESS',
-  'ARTICLE',
-  'ASIDE',
-  'BLOCKQUOTE',
-  'DETAILS',
-  'DIALOG',
-  'DD',
-  'DIV',
-  'DL',
-  'DT',
-  'FIELDSET',
-  'FIGCAPTION',
-  'FIGURE',
-  'FOOTER',
-  'FORM',
-  'H1',
-  'H2',
-  'H3',
-  'H4',
-  'H5',
-  'H6',
-  'HEADER',
-  'HGROUP',
-  'HR',
-  'LI',
-  'MAIN',
-  'NAV',
-  'OL',
-  'P',
-  'PRE',
-  'SECTION',
-  'TABLE',
-  'UL',
+  'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'DETAILS',  'DIALOG',
+  'DD',      'DIV',     'DL',    'DT',         'FIELDSET', 'FIGCAPTION',
+  'FIGURE',  'FOOTER',  'FORM',  'H1',         'H2',       'H3',
+  'H4',      'H5',      'H6',    'HEADER',     'HGROUP',   'HR',
+  'LI',      'MAIN',    'NAV',   'OL',         'P',        'PRE',
+  'SECTION', 'TABLE',   'UL',
 ];
 
 // Characters that indicate a word boundary. Use the script
 // tools/generate-boundary-regex.js if it's necessary to modify or regenerate
 // this. Because it's a hefty regex, this should be used infrequently and only
 // on single-character strings.
-const BOUNDARY_CHARS = /[\t-\r -#%-\*,-\/:;\?@\[-\]_\{\}\x85\xA0\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u1680\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2000-\u200A\u2010-\u2029\u202F-\u2043\u2045-\u2051\u2053-\u205F\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E44\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/u;
+const BOUNDARY_CHARS =
+    /[\t-\r -#%-\*,-\/:;\?@\[-\]_\{\}\x85\xA0\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u1680\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2000-\u200A\u2010-\u2029\u202F-\u2043\u2045-\u2051\u2053-\u205F\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E44\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/u;
 
 /**
  * Get all text fragments from a string
@@ -75,43 +49,45 @@ const BOUNDARY_CHARS = /[\t-\r -#%-\*,-\/:;\?@\[-\]_\{\}\x85\xA0\xA1\xA7\xAB\xB6
  * @return {{text: string[]}} Text Fragments contained in the hash.
  */
 export const getFragmentDirectives = (hash) => {
-  const fragmentDirectivesStrings = hash
-    .replace(/#.*?:~:(.*?)/, '$1')
-    .split(/&?text=/)
-    .filter(Boolean);
+  const fragmentDirectivesStrings =
+      hash.replace(/#.*?:~:(.*?)/, '$1').split(/&?text=/).filter(Boolean);
   if (!fragmentDirectivesStrings.length) {
     return {};
   } else {
-    return { text: fragmentDirectivesStrings };
+    return {text: fragmentDirectivesStrings};
   }
 };
 
 /**
- * Decompose text fragment strings into objects, describing each part of each text fragment.
- * @param {{text: string[]}} fragmentDirectives - Text fragment to decompose into separate elements.
- * @return {{text: TextFragment[]}} Text Fragments, each containing textStart, textEnd, prefix and suffix.
+ * Decompose text fragment strings into objects, describing each part of each
+ * text fragment.
+ * @param {{text: string[]}} fragmentDirectives - Text fragment to decompose
+ *     into separate elements.
+ * @return {{text: TextFragment[]}} Text Fragments, each containing textStart,
+ *     textEnd, prefix and suffix.
  */
 export const parseFragmentDirectives = (fragmentDirectives) => {
   const parsedFragmentDirectives = {};
-  for (const [
-    fragmentDirectiveType,
-    fragmentDirectivesOfType,
+  for (const
+           [fragmentDirectiveType,
+            fragmentDirectivesOfType,
   ] of Object.entries(fragmentDirectives)) {
     if (FRAGMENT_DIRECTIVES.includes(fragmentDirectiveType)) {
-      parsedFragmentDirectives[
-        fragmentDirectiveType
-      ] = fragmentDirectivesOfType.map((fragmentDirectiveOfType) => {
-        return parseTextFragmentDirective(fragmentDirectiveOfType);
-      });
+      parsedFragmentDirectives[fragmentDirectiveType] =
+          fragmentDirectivesOfType.map((fragmentDirectiveOfType) => {
+            return parseTextFragmentDirective(fragmentDirectiveOfType);
+          });
     }
   }
   return parsedFragmentDirectives;
 };
 
 /**
- * Decompose a string into an object containing all the parts of a text fragment.
+ * Decompose a string into an object containing all the parts of a text
+ * fragment.
  * @param {string} textFragment - String to decompose.
- * @return {TextFragment} Object containing textStart, textEnd, prefix and suffix of the text fragment.
+ * @return {TextFragment} Object containing textStart, textEnd, prefix and
+ *     suffix of the text fragment.
  */
 const parseTextFragmentDirective = (textFragment) => {
   const TEXT_FRAGMENT = /^(?:(.+?)-,)?(?:(.+?))(?:,([^-]+?))?(?:,-(.+?))?$/;
@@ -125,21 +101,22 @@ const parseTextFragmentDirective = (textFragment) => {
 
 /**
  * Mark the text fragments with `<mark>` tags.
- * @param {{text: TextFragment[]}} parsedFragmentDirectives - Text fragments to process.
- * @return {{text: (Element[])[]}} `<mark>` elements created to highlight the text fragments.
+ * @param {{text: TextFragment[]}} parsedFragmentDirectives - Text fragments to
+ *     process.
+ * @return {{text: (Element[])[]}} `<mark>` elements created to highlight the
+ *     text fragments.
  */
 export const processFragmentDirectives = (parsedFragmentDirectives) => {
   const processedFragmentDirectives = {};
-  for (const [
-    fragmentDirectiveType,
-    fragmentDirectivesOfType,
+  for (const
+           [fragmentDirectiveType,
+            fragmentDirectivesOfType,
   ] of Object.entries(parsedFragmentDirectives)) {
     if (FRAGMENT_DIRECTIVES.includes(fragmentDirectiveType)) {
-      processedFragmentDirectives[
-        fragmentDirectiveType
-      ] = fragmentDirectivesOfType.map((fragmentDirectiveOfType) => {
-        return processTextFragmentDirective(fragmentDirectiveOfType);
-      });
+      processedFragmentDirectives[fragmentDirectiveType] =
+          fragmentDirectivesOfType.map((fragmentDirectiveOfType) => {
+            return processTextFragmentDirective(fragmentDirectiveOfType);
+          });
     }
   }
   return processedFragmentDirectives;
@@ -167,9 +144,9 @@ export const processTextFragmentDirective = (textFragment) => {
       // Future iterations, if necessary, should start after the first character
       // of the prefix match.
       advanceRangeStartPastOffset(
-        searchRange,
-        prefixMatch.startContainer,
-        prefixMatch.startOffset,
+          searchRange,
+          prefixMatch.startContainer,
+          prefixMatch.startOffset,
       );
 
       // The search space for textStart is everything after the prefix and
@@ -194,12 +171,10 @@ export const processTextFragmentDirective = (textFragment) => {
       // equals matchRange's start), this is a candidate and we should keep
       // going with this iteration. Otherwise, we'll need to find the next
       // instance (if any) of the prefix.
-      if (
-        potentialMatch.compareBoundaryPoints(
-          Range.START_TO_START,
-          matchRange,
-        ) !== 0
-      ) {
+      if (potentialMatch.compareBoundaryPoints(
+              Range.START_TO_START,
+              matchRange,
+              ) !== 0) {
         continue;
       }
     } else {
@@ -209,17 +184,17 @@ export const processTextFragmentDirective = (textFragment) => {
         return [];
       }
       advanceRangeStartPastOffset(
-        searchRange,
-        potentialMatch.startContainer,
-        potentialMatch.startOffset,
+          searchRange,
+          potentialMatch.startContainer,
+          potentialMatch.startOffset,
       );
     }
 
     if (textFragment.textEnd) {
       const textEndRange = document.createRange();
       textEndRange.setStart(
-        potentialMatch.endContainer,
-        potentialMatch.endOffset,
+          potentialMatch.endContainer,
+          potentialMatch.endOffset,
       );
       textEndRange.setEnd(searchRange.endContainer, searchRange.endOffset);
       const textEndMatch = findTextInRange(textFragment.textEnd, textEndRange);
@@ -232,8 +207,8 @@ export const processTextFragmentDirective = (textFragment) => {
     if (textFragment.suffix) {
       const suffixRange = document.createRange();
       suffixRange.setStart(
-        potentialMatch.endContainer,
-        potentialMatch.endOffset,
+          potentialMatch.endContainer,
+          potentialMatch.endOffset,
       );
       suffixRange.setEnd(searchRange.endContainer, searchRange.endOffset);
       advanceRangeStartToNonBoundary(suffixRange);
@@ -248,10 +223,8 @@ export const processTextFragmentDirective = (textFragment) => {
       // If suffixMatch is immediately after potentialMatch (i.e., its start
       // equals suffixRange's start), this is a match. If not, we have to
       // start over from the beginning.
-      if (
-        suffixMatch.compareBoundaryPoints(Range.START_TO_START, suffixRange) !==
-        0
-      ) {
+      if (suffixMatch.compareBoundaryPoints(
+              Range.START_TO_START, suffixRange) !== 0) {
         continue;
       }
     }
@@ -283,11 +256,11 @@ const advanceRangeStartPastOffset = (range, node, offset) => {
  */
 const advanceRangeStartToNonBoundary = (range) => {
   const walker = document.createTreeWalker(
-    range.commonAncestorContainer,
-    NodeFilter.SHOW_TEXT,
-    (node) => {
-      return filterFunction(node, range);
-    },
+      range.commonAncestorContainer,
+      NodeFilter.SHOW_TEXT,
+      (node) => {
+        return filterFunction(node, range);
+      },
   );
   let node = walker.nextNode();
   while (!range.collapsed && node != null) {
@@ -324,10 +297,8 @@ const advanceRangeStartToNonBoundary = (range) => {
  * @return {Element[]} The <mark> nodes that were created.
  */
 const markRange = (range) => {
-  if (
-    range.startContainer.nodeType != Node.TEXT_NODE ||
-    range.endContainer.nodeType != Node.TEXT_NODE
-  )
+  if (range.startContainer.nodeType != Node.TEXT_NODE ||
+      range.endContainer.nodeType != Node.TEXT_NODE)
     return [];
 
   // If the range is entirely within a single node, just surround it.
@@ -352,20 +323,18 @@ const markRange = (range) => {
   range.setStartAfter(startNode);
   range.setEndBefore(endNode);
   const walker = document.createTreeWalker(
-    range.commonAncestorContainer,
-    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
-    {
-      acceptNode: function (node) {
-        if (!range.intersectsNode(node)) return NodeFilter.FILTER_REJECT;
+      range.commonAncestorContainer,
+      NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+      {
+        acceptNode: function(node) {
+          if (!range.intersectsNode(node)) return NodeFilter.FILTER_REJECT;
 
-        if (
-          BLOCK_ELEMENTS.includes(node.tagName) ||
-          node.nodeType === Node.TEXT_NODE
-        )
-          return NodeFilter.FILTER_ACCEPT;
-        return NodeFilter.FILTER_SKIP;
+          if (BLOCK_ELEMENTS.includes(node.tagName) ||
+              node.nodeType === Node.TEXT_NODE)
+            return NodeFilter.FILTER_ACCEPT;
+          return NodeFilter.FILTER_SKIP;
+        },
       },
-    },
   );
   let node = walker.nextNode();
   while (node) {
@@ -419,13 +388,9 @@ const filterFunction = (node, range) => {
   if (elt != null) {
     const nodeStyle = window.getComputedStyle(elt);
     // If the node is not rendered, just skip it.
-    if (
-      nodeStyle.visibility === 'hidden' ||
-      nodeStyle.display === 'none' ||
-      nodeStyle.height === 0 ||
-      nodeStyle.width === 0 ||
-      nodeStyle.opacity === 0
-    ) {
+    if (nodeStyle.visibility === 'hidden' || nodeStyle.display === 'none' ||
+        nodeStyle.height === 0 || nodeStyle.width === 0 ||
+        nodeStyle.opacity === 0) {
       return NodeFilter.FILTER_REJECT;
     }
   }
@@ -445,19 +410,19 @@ const getAllTextNodes = (root, range) => {
   let tmp = [];
 
   const nodes = Array.from(
-    getElementsIn(root, (node) => {
-      return filterFunction(node, range);
-    }),
+      getElementsIn(
+          root,
+          (node) => {
+            return filterFunction(node, range);
+          }),
   );
 
   for (const node of nodes) {
     if (node.nodeType === Node.TEXT_NODE) {
       tmp.push(node);
     } else if (
-      node instanceof HTMLElement &&
-      BLOCK_ELEMENTS.includes(node.tagName) &&
-      tmp.length > 0
-    ) {
+        node instanceof HTMLElement && BLOCK_ELEMENTS.includes(node.tagName) &&
+        tmp.length > 0) {
       // If this is a block element, the current set of text nodes in |tmp| is
       // complete, and we need to move on to a new one.
       blocks.push(tmp);
@@ -470,21 +435,22 @@ const getAllTextNodes = (root, range) => {
 };
 
 /**
- * Returns the textContent of all the textNodes and normalizes strings by replacing duplicated spaces with single space.
+ * Returns the textContent of all the textNodes and normalizes strings by
+ * replacing duplicated spaces with single space.
  * @param {Node[]} nodes - TextNodes to get the textContent from.
  * @param {Number} startOffset - Where to start in the first TextNode.
  * @param {Number|undefined} endOffset Where to end in the last TextNode.
- * @return {string} Entire text content of all the nodes, with spaces normalized.
+ * @return {string} Entire text content of all the nodes, with spaces
+ *     normalized.
  */
 const getTextContent = (nodes, startOffset, endOffset) => {
   let str = '';
   if (nodes.length === 1) {
     str = nodes[0].textContent.substring(startOffset, endOffset);
   } else {
-    str =
-      nodes[0].textContent.substring(startOffset) +
-      nodes.slice(1, -1).reduce((s, n) => s + n.textContent, '') +
-      nodes.slice(-1)[0].textContent.substring(0, endOffset);
+    str = nodes[0].textContent.substring(startOffset) +
+        nodes.slice(1, -1).reduce((s, n) => s + n.textContent, '') +
+        nodes.slice(-1)[0].textContent.substring(0, endOffset);
   }
   return str.replace(/[\t\n\r ]+/g, ' ');
 };
@@ -492,21 +458,23 @@ const getTextContent = (nodes, startOffset, endOffset) => {
 /**
  * @callback ElementFilterFunction
  * @param {HTMLElement} element - Node to accept, reject or skip.
- * @returns {number} Either NodeFilter.FILTER_ACCEPT, NodeFilter.FILTER_REJECT or NodeFilter.FILTER_SKIP.
+ * @returns {number} Either NodeFilter.FILTER_ACCEPT, NodeFilter.FILTER_REJECT
+ *     or NodeFilter.FILTER_SKIP.
  */
 
 /**
  * Returns all nodes inside root using the provided filter.
  * @generator
  * @param {Node} root - Node where to start the TreeWalker.
- * @param {ElementFilterFunction} filter - Filter provided to the TreeWalker's acceptNode filter.
+ * @param {ElementFilterFunction} filter - Filter provided to the TreeWalker's
+ *     acceptNode filter.
  * @yield {HTMLElement} All elements that were accepted by filter.
  */
 function* getElementsIn(root, filter) {
   const treeWalker = document.createTreeWalker(
-    root,
-    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
-    { acceptNode: filter },
+      root,
+      NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+      {acceptNode: filter},
   );
 
   let currentNode;
@@ -554,9 +522,9 @@ const findRangeFromNodeList = (query, range, textNodes) => {
     if (isWordBounded(data, matchIndex, normalizedQuery.length)) {
       start = getBoundaryPointAtIndex(matchIndex, textNodes, /* isEnd=*/ false);
       end = getBoundaryPointAtIndex(
-        matchIndex + normalizedQuery.length,
-        textNodes,
-        /* isEnd=*/ true,
+          matchIndex + normalizedQuery.length,
+          textNodes,
+          /* isEnd=*/ true,
       );
     } else {
       searchStart = matchIndex + 1;
@@ -569,10 +537,8 @@ const findRangeFromNodeList = (query, range, textNodes) => {
     foundRange.setEnd(end.node, end.offset);
 
     // Verify that |foundRange| is a subrange of |range|
-    if (
-      range.compareBoundaryPoints(Range.START_TO_START, foundRange) <= 0 &&
-      range.compareBoundaryPoints(Range.END_TO_END, foundRange) >= 0
-    ) {
+    if (range.compareBoundaryPoints(Range.START_TO_START, foundRange) <= 0 &&
+        range.compareBoundaryPoints(Range.END_TO_END, foundRange) >= 0) {
       return foundRange;
     }
   }
@@ -613,35 +579,32 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
 
       // Walk through the string until denormalizedOffset produces a substring
       // that corresponds to the target from the normalized data.
-      const targetSubstring = isEnd
-        ? normalizedData.substring(0, normalizedOffset)
-        : normalizedData.substring(normalizedOffset);
+      const targetSubstring = isEnd ?
+          normalizedData.substring(0, normalizedOffset) :
+          normalizedData.substring(normalizedOffset);
 
-      let candidateSubstring = isEnd
-        ? normalizeString(node.data.substring(0, denormalizedOffset))
-        : normalizeString(node.data.substring(denormalizedOffset));
+      let candidateSubstring = isEnd ?
+          normalizeString(node.data.substring(0, denormalizedOffset)) :
+          normalizeString(node.data.substring(denormalizedOffset));
 
       // We will either lengthen or shrink the candidate string to approach the
       // length of the target string. If we're looking for the start, adding 1
       // makes the candidate shorter; if we're looking for the end, it makes the
       // candidate longer.
-      const direction =
-        (isEnd ? -1 : 1) *
-        (targetSubstring.length > candidateSubstring.length ? -1 : 1);
+      const direction = (isEnd ? -1 : 1) *
+          (targetSubstring.length > candidateSubstring.length ? -1 : 1);
 
-      while (
-        denormalizedOffset >= 0 &&
-        denormalizedOffset <= node.data.length
-      ) {
+      while (denormalizedOffset >= 0 &&
+             denormalizedOffset <= node.data.length) {
         if (candidateSubstring.length === targetSubstring.length) {
-          return { node: node, offset: denormalizedOffset };
+          return {node: node, offset: denormalizedOffset};
         }
 
         denormalizedOffset += direction;
 
-        candidateSubstring = isEnd
-          ? normalizeString(node.data.substring(0, denormalizedOffset))
-          : normalizeString(node.data.substring(denormalizedOffset));
+        candidateSubstring = isEnd ?
+            normalizeString(node.data.substring(0, denormalizedOffset)) :
+            normalizeString(node.data.substring(denormalizedOffset));
       }
     }
     counted += normalizedData.length;
@@ -651,10 +614,8 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
       // node starts with one, they'll be double-counted relative to the
       // normalized version. Subtract 1 from |counted| to compensate.
       const nextNormalizedData = normalizeString(textNodes[i + 1].data);
-      if (
-        normalizedData.slice(-1) === ' ' &&
-        nextNormalizedData.slice(0, 1) === ' '
-      ) {
+      if (normalizedData.slice(-1) === ' ' &&
+          nextNormalizedData.slice(0, 1) === ' ') {
         counted -= 1;
       }
       // Since we already normalized the next node's data, hold on to it for the
@@ -682,21 +643,15 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
  *     substring of |text|.
  */
 const isWordBounded = (text, startPos, length) => {
-  if (
-    startPos < 0 ||
-    startPos >= text.length ||
-    length <= 0 ||
-    startPos + length > text.length
-  ) {
+  if (startPos < 0 || startPos >= text.length || length <= 0 ||
+      startPos + length > text.length) {
     return false;
   }
 
   if (startPos !== 0 && !text[startPos - 1].match(BOUNDARY_CHARS)) return false;
 
-  if (
-    startPos + length !== text.length &&
-    !text[startPos + length].match(BOUNDARY_CHARS)
-  )
+  if (startPos + length !== text.length &&
+      !text[startPos + length].match(BOUNDARY_CHARS))
     return false;
 
   return true;
@@ -714,10 +669,10 @@ const normalizeString = (str) => {
   // anything in the Unicode U+0300..U+036F (Combining Diacritical Marks) range.
   // This may change the length of the string.
   return (str || '')
-    .normalize('NFKD')
-    .replace(/\s+/g, ' ')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase();
+      .normalize('NFKD')
+      .replace(/\s+/g, ' ')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
 };
 
 export const forTesting = {
@@ -735,5 +690,6 @@ export const forTesting = {
 // to ES6 modules.
 if (typeof goog !== 'undefined') {
   // prettier-ignore
-  goog.declareModuleId('googleChromeLabs.textFragmentPolyfill.textFragmentUtils');
+  goog.declareModuleId(
+      'googleChromeLabs.textFragmentPolyfill.textFragmentUtils');
 }

--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -31,10 +31,10 @@ import * as utils from './text-fragment-utils.js';
   const init = () => {
     const fragmentDirectives = utils.getFragmentDirectives(hash);
     const parsedFragmentDirectives = utils.parseFragmentDirectives(
-      fragmentDirectives,
+        fragmentDirectives,
     );
     const processedFragmentDirectives = utils.processFragmentDirectives(
-      parsedFragmentDirectives,
+        parsedFragmentDirectives,
     );
     const createdMarks = processedFragmentDirectives['text'];
     const firstFoundMatch = createdMarks.find((marks) => marks.length)[0];

--- a/tools/generate-boundary-regex.js
+++ b/tools/generate-boundary-regex.js
@@ -24,7 +24,10 @@
  */
 
 const regenerate = require('regenerate');
-const set = regenerate()
-  .add(require('unicode-9.0.0/General_Category/Punctuation/code-points.js'))
-  .add(require('unicode-9.0.0/Binary_Property/White_Space/code-points.js'));
+const set =
+    regenerate()
+        .add(require(
+            'unicode-9.0.0/General_Category/Punctuation/code-points.js'))
+        .add(require(
+            'unicode-9.0.0/Binary_Property/White_Space/code-points.js'));
 console.log('/' + set.toString() + '/u');


### PR DESCRIPTION
For consistency, this changes the install scripts to use clang-format and Google JS style, rather than Prettier style. It also updates the affected source files to apply the new formatting.