### PR TITLE
Stubbing out generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -17,9 +17,9 @@
 /**
  * @typedef {Object} TextFragment
  * @property {string} textStart
- * @property {string} textEnd
- * @property {string} prefix
- * @property {string} suffix
+ * @property {string} [textEnd]
+ * @property {string} [prefix]
+ * @property {string} [suffix]
  */
 
 const FRAGMENT_DIRECTIVES = ['text'];
@@ -262,6 +262,45 @@ export const removeMarks = (marks) => {
     parent.insertBefore(fragment, mark);
     parent.removeChild(mark);
   }
+};
+
+/**
+ * Enum indicating the success, or failure reason, of generateFragment.
+ */
+export const GenerateFragmentStatus = {
+  SUCCESS: 0,            // A fragment was generated.
+  INVALID_SELECTION: 1,  // The selection provided could not be used.
+  AMBIGUOUS: 2  // No unique fragment could be identified for this selection.
+}
+
+/**
+ * @typedef {Object} GenerateFragmentResult
+ * @property {GenerateFragmentStatus} status
+ * @property {TextFragment} [fragment]
+ */
+
+/**
+ * Attempts to generate a fragment, suitable for formatting and including in a
+ * URL, which will highlight the given selection upon opening.
+ * @param {Selection} selection - a Selection object, the result of
+ *     window.getSelection
+ * @return {GenerateFragmentResult}
+ */
+export const generateFragment = (selection) => {
+  let range;
+  try {
+    range = selection.getRangeAt(0);
+  } catch {
+    return {status: GenerateFragmentStatus.INVALID_SELECTION};
+  }
+
+  // TODO: Implement a robust algorithm here which is sensitive to block
+  //    boundaries and uniqueness.
+
+  return {
+    status: GenerateFragmentStatus.SUCCESS,
+    fragment: {textStart: range.toString()}
+  };
 };
 
 /**

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -185,6 +185,25 @@ describe('TextFragmentUtils', function () {
     expect(document.body.innerHTML).toEqual(__html__['marks_test.html']);
   });
 
+  it('can generate a fragment for an exact match', function () {
+    document.body.innerHTML = __html__['basic_test.html'];
+    const range = document.createRange();
+    // firstChild of body is a <p>; firstChild of <p> is a text node.
+    range.selectNodeContents(document.body.firstChild.firstChild);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    
+    const result = utils.generateFragment(selection);
+    expect(result.status).toEqual(utils.GenerateFragmentStatus.SUCCESS);
+    expect(result.fragment.textStart).not.toBeUndefined();
+    expect(result.fragment.textStart).toEqual(
+        "This is a trivial test of the marking logic.");
+    expect(result.fragment.textEnd).toBeUndefined();
+    expect(result.fragment.prefix).toBeUndefined();
+    expect(result.fragment.suffix).toBeUndefined();
+  });
+  
   it('can normalize text', function () {
     // Dict mapping inputs to expected outputs.
     const testCases = {


### PR DESCRIPTION
This patch adds a stub method for generating a fragment. The logic inside is currently super simple (just drops the plain text into the textStart value) but it should define the API well enough that work on integrations can start.