### PR TITLE
Bump to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "src/text-fragments.js",
   "browser": "src/text-fragments.js",


### PR DESCRIPTION
This bumps the version to 1.0.0. Work on parsing, finding, and highlighting text fragments is now complete (though future versions will include improvements and bug fixes).