### PR TITLE
Stubbing out generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "src/text-fragments.js",
   "browser": "src/text-fragments.js",
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "npx http-server",
     "clean": "shx rm -rf dist",
-    "fix": "npx clang-format --style=Google -i ./src/*.js ./tools/*.js && npx prettier --write **/*.json **/*.html",
+    "fix": "npx clang-format --style=Google -i ./src/*.js ./tools/*.js ./test/*.js && npx prettier --write **/*.json **/*.html",
     "prepare": "npm run clean && npm run fix && npm run lint && npx rollup src/text-fragments.js --dir dist -p 'terser'",
     "lint": "npx eslint . --ext .js,.mjs --fix --ignore-pattern dist/",
     "test": "./node_modules/karma/bin/karma start --single-run"

--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fragments from './text-fragment-utils.js';
+
+/**
+ * Enum indicating the success, or failure reason, of generateFragment.
+ */
+export const GenerateFragmentStatus = {
+  SUCCESS: 0,            // A fragment was generated.
+  INVALID_SELECTION: 1,  // The selection provided could not be used.
+  AMBIGUOUS: 2  // No unique fragment could be identified for this selection.
+}
+
+/**
+ * @typedef {Object} GenerateFragmentResult
+ * @property {GenerateFragmentStatus} status
+ * @property {TextFragment} [fragment]
+ */
+
+/**
+ * Attempts to generate a fragment, suitable for formatting and including in a
+ * URL, which will highlight the given selection upon opening.
+ * @param {Selection} selection - a Selection object, the result of
+ *     window.getSelection
+ * @return {GenerateFragmentResult}
+ */
+export const generateFragment = (selection) => {
+  let range;
+  try {
+    range = selection.getRangeAt(0);
+  } catch {
+    return {status: GenerateFragmentStatus.INVALID_SELECTION};
+  }
+
+  // TODO: Implement a robust algorithm here which is sensitive to block
+  //    boundaries and uniqueness.
+
+  return {
+    status: GenerateFragmentStatus.SUCCESS,
+    fragment: {textStart: fragments.internal.normalizeString(range.toString())}
+  };
+};
+
+// Allow importing module from closure-compiler projects that haven't migrated
+// to ES6 modules.
+if (typeof goog !== 'undefined') {
+  // clang-format off
+  goog.declareModuleId('googleChromeLabs.textFragmentPolyfill.fragmentGenerationUtils');
+  // clang-format on
+}

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -17,9 +17,9 @@
 /**
  * @typedef {Object} TextFragment
  * @property {string} textStart
- * @property {string} textEnd
- * @property {string} prefix
- * @property {string} suffix
+ * @property {string} [textEnd]
+ * @property {string} [prefix]
+ * @property {string} [suffix]
  */
 
 const FRAGMENT_DIRECTIVES = ['text'];
@@ -752,6 +752,9 @@ const normalizeString = (str) => {
       .toLowerCase();
 };
 
+/**
+ * Should not be referenced except in the /test directory.
+ */
 export const forTesting = {
   advanceRangeStartPastOffset: advanceRangeStartPastOffset,
   advanceRangeStartToNonBoundary: advanceRangeStartToNonBoundary,
@@ -762,6 +765,13 @@ export const forTesting = {
   markRange: markRange,
   normalizeString: normalizeString,
 };
+
+/**
+ * Should only be used by other files in this directory.
+ */
+export const internal = {
+  normalizeString: normalizeString,
+}
 
 // Allow importing module from closure-compiler projects that haven't migrated
 // to ES6 modules.

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -1,0 +1,22 @@
+import * as utils from '../src/fragment-generation-utils.js';
+
+describe('FragmentGenerationUtils', function() {
+  it('can generate a fragment for an exact match', function() {
+    document.body.innerHTML = __html__['basic_test.html'];
+    const range = document.createRange();
+    // firstChild of body is a <p>; firstChild of <p> is a text node.
+    range.selectNodeContents(document.body.firstChild.firstChild);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const result = utils.generateFragment(selection);
+    expect(result.status).toEqual(utils.GenerateFragmentStatus.SUCCESS);
+    expect(result.fragment.textStart).not.toBeUndefined();
+    expect(result.fragment.textStart)
+        .toEqual('this is a trivial test of the marking logic.');
+    expect(result.fragment.textEnd).toBeUndefined();
+    expect(result.fragment.prefix).toBeUndefined();
+    expect(result.fragment.suffix).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This patch:
* Defines the high-level interface for fragment generation, with a stub that should allow us to start testing integrations
* Adds a new file which will contain this logic moving forward
* Bumps the version to 1.1 to reflect the new (in-development) functionality
* Adds test files to automatic formatting