### PR TITLE
Expanding selection during fragment generation to word start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "0.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -46,13 +46,116 @@ export const generateFragment = (selection) => {
     return {status: GenerateFragmentStatus.INVALID_SELECTION};
   }
 
-  // TODO: Implement a robust algorithm here which is sensitive to block
-  //    boundaries and uniqueness.
+  expandRangeStartToWordBound(range);
 
   return {
     status: GenerateFragmentStatus.SUCCESS,
     fragment: {textStart: fragments.internal.normalizeString(range.toString())}
   };
+};
+
+/**
+ * Attempts to find a word start within the given text node, starting at
+ * |offset| and working backwards.
+ *
+ * @param {Node} node - a node to be searched
+ * @param {Number|Undefined} startOffset - the character offset within |node|
+ *     where the selected text begins. If undefined, the
+ * @return {Number} the number indicating the offset to which a range should
+ *     be set to ensure it starts on a word bound. Returns -1 if the node is not
+ *     a text node, or if no word boundary character could be found.
+ */
+const findWordStartBoundInTextNode = (node, startOffset) => {
+  if (node.nodeType !== Node.TEXT_NODE) return -1;
+
+  const offset = startOffset != null ? startOffset : node.data.length;
+
+  // If the first character in the range is a boundary character, we don't
+  // need to do anything.
+  if (offset < node.data.length &&
+      fragments.internal.BOUNDARY_CHARS.test(node.data[offset]))
+    return offset;
+
+  const precedingText = node.data.substring(0, offset);
+  // Search backwards through text for a boundary char. Spread operator (...)
+  // splits full characters, rather than code points, to avoid breaking
+  // unicode characters upon reverse.
+  const boundaryIndex = [...precedingText].reverse().join('').search(
+      fragments.internal.BOUNDARY_CHARS);
+
+  if (boundaryIndex !== -1) {
+    // Because we did a backwards search, the found index counts backwards
+    // from offset, so we subtract to find the start of the word.
+    return offset - boundaryIndex;
+  }
+  return -1;
+};
+
+/**
+ * Modifies the start of the range, if necessary, to ensure the selection text
+ * starts after a boundary char (whitespace, etc.) or a block boundary. Can only
+ * expand the range, not shrink it.
+ * @param {Range} range - the range to be modified
+ */
+const expandRangeStartToWordBound = (range) => {
+  // Simplest case: If we're in a text node, try to find a boundary char in the
+  // same text node.
+  const newOffset =
+      findWordStartBoundInTextNode(range.startContainer, range.startOffset);
+  if (newOffset !== -1) {
+    range.setStart(range.startContainer, newOffset);
+    return;
+  }
+
+  // Find a block-level ancestor of the range's start node by walking up the
+  // tree. This will be used as the root of the tree walker.
+  let blockAncestor = range.startContainer;
+  while (!fragments.internal.BLOCK_ELEMENTS.includes(blockAncestor.tagName) &&
+         blockAncestor.tagName !== 'HTML' && blockAncestor.tagName !== 'BODY') {
+    blockAncestor = blockAncestor.parentNode;
+  }
+  const walker = document.createTreeWalker(
+      blockAncestor, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, (node) => {
+        return fragments.internal.filterFunction(node);
+      });
+
+  walker.currentNode = range.startContainer;
+  let node = walker.previousNode();
+  while (node != null) {
+    const newOffset = findWordStartBoundInTextNode(node);
+    if (newOffset !== -1) {
+      range.setStart(node, newOffset);
+      return;
+    }
+
+    // If |node| is a block node, then we've hit a block boundary, which counts
+    // as a word boundary.
+    if (node.nodeType === Node.ELEMENT_NODE &&
+        (fragments.internal.BLOCK_ELEMENTS.includes(node.tagName) ||
+         node.tagName === 'HTML' || node.tagName === 'BODY')) {
+      if (node.contains(range.startContainer)) {
+        // If the selection starts inside |node|, then the correct range
+        // boundary is the *leading* edge of |node|.
+        range.setStart(node, 0);
+      } else {
+        // Otherwise, |node| is before the selection, so the correct boundary is
+        // the *trailing* edge of |node|.
+        range.setStartAfter(node);
+      }
+      return;
+    }
+
+    node = walker.previousNode();
+  }
+  // We should never get here; the walker should eventually hit a block node
+  // or the root of the document. Collapse range so the caller can handle this
+  // as an error.
+  range.collapse();
+};
+
+export const forTesting = {
+  expandRangeStartToWordBound: expandRangeStartToWordBound,
+  findWordStartBoundInTextNode: findWordStartBoundInTextNode,
 };
 
 // Allow importing module from closure-compiler projects that haven't migrated

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -770,6 +770,9 @@ export const forTesting = {
  * Should only be used by other files in this directory.
  */
 export const internal = {
+  BLOCK_ELEMENTS: BLOCK_ELEMENTS,
+  BOUNDARY_CHARS: BOUNDARY_CHARS,
+  filterFunction: filterFunction,
   normalizeString: normalizeString,
 }
 

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -19,4 +19,77 @@ describe('FragmentGenerationUtils', function() {
     expect(result.fragment.prefix).toBeUndefined();
     expect(result.fragment.suffix).toBeUndefined();
   });
+
+  it('can find a word boundary inside a text node', function() {
+    document.body.innerHTML = __html__['word_bounds_test.html'];
+    const elt = document.getElementById('block');
+
+    // elt is an HTML element, not a text node, so we should find -1
+    let result = utils.forTesting.findWordStartBoundInTextNode(elt);
+    expect(result).toEqual(-1);
+
+    const node = elt.firstChild;
+    // With no second arg, we find the first from the end
+    result = utils.forTesting.findWordStartBoundInTextNode(node);
+    expect(result).toEqual(7);  // Between " " and "b"
+
+    // Second arg in the middle of a word
+    result = utils.forTesting.findWordStartBoundInTextNode(node, 10);
+    expect(result).toEqual(7);  // Between " " and "b"
+
+    // Second arg immediately *before* a space should give the same output
+    result = utils.forTesting.findWordStartBoundInTextNode(node, 6);
+    expect(result).toEqual(6)
+
+    // No more spaces to the left of second arg, -1
+    result = utils.forTesting.findWordStartBoundInTextNode(node, 3);
+    expect(result).toEqual(-1);
+  });
+
+  it('can expand a range start to a word bound within a node', function() {
+    document.body.innerHTML = __html__['word_bounds_test.html'];
+    const range = document.createRange();
+    const textNodeInBlock = document.getElementById('block').firstChild;
+
+    range.setStart(textNodeInBlock, 10);
+    range.setEnd(textNodeInBlock, 12);
+    expect(range.toString()).toEqual('ck');
+
+    utils.forTesting.expandRangeStartToWordBound(range);
+    expect(range.toString()).toEqual('block');
+  });
+
+  it('can expand a range start to an inner block boundary', function() {
+    document.body.innerHTML = __html__['word_bounds_test.html'];
+    const range = document.createRange();
+    const textNodeInBlock = document.getElementById('block').firstChild;
+
+    range.setStart(textNodeInBlock, 3);
+    range.setEnd(textNodeInBlock, 12);
+    expect(range.toString()).toEqual('ide block');
+
+    utils.forTesting.expandRangeStartToWordBound(range);
+    expect(range.toString()).toEqual('Inside block');
+  });
+
+  it('can expand a range start across inline elements', function() {
+    document.body.innerHTML = __html__['word_bounds_test.html'];
+    const range = document.createRange();
+    const inlineTextNode = document.getElementById('inline').firstChild;
+    const lastTextNode = document.getElementById('root').lastChild;
+
+    range.setStart(inlineTextNode, 1);
+    range.setEnd(lastTextNode, 2);
+    expect(range.toString()).toEqual('ine');
+
+    utils.forTesting.expandRangeStartToWordBound(range);
+    expect(range.toString()).toEqual('Inline');
+
+    range.setStart(lastTextNode, 1);
+    range.setEnd(lastTextNode, 2);
+    expect(range.toString()).toEqual('e');
+
+    utils.forTesting.expandRangeStartToWordBound(range);
+    expect(range.toString()).toEqual('Inline');
+  });
 });

--- a/test/word_bounds_test.html
+++ b/test/word_bounds_test.html
@@ -1,0 +1,5 @@
+<div id="root">
+  <!-- prettier-ignore -->
+  <p id="block">Inside block</p>
+  In<i id="inline">li</i>ne
+</div>


### PR DESCRIPTION
This patch makes the fragment generation process respect word and
block boundaries by expanding the start of the user selection (if
necessary).

End boundaries will follow similar logic but the logic was already
pretty complex just for one side, so I will tackle that in a follow-up.