### PR TITLE
Using override map approach for traversal

### DIFF
--- a/test/postorder-tree.html
+++ b/test/postorder-tree.html
@@ -1,11 +1,12 @@
-<div id="h">
-  <div id="c">
-    <div id="b">a</div>
-  </div>
+<div id="i">
   <div id="d">
-    <div id="e"></div>
-    <div id="f">
-      <div id="g"></div>
+    <div id="b">a</div>
+    <div id="c"></div>
+  </div>
+  <div id="e">
+    <div id="f"></div>
+    <div id="g">
+      <div id="h"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Currently when trying to find block boundaries in the forward
direction, we use a postorder traversal so that the ends of blocks
can be found. However, this only makes sense if the traversal
started inside those nodes--otherwise, we'd want to hit the
leading edge. This change adopts a new approach based on
"injecting" these ancestor nodes into the traversal order using an
override map. This solves the known bugs (the disabled test).