### PR TITLE
Implementing backwardTraverse

### DIFF
--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -185,15 +185,34 @@ describe('FragmentGenerationUtils', function() {
 
   it('can traverse in order for finding block boundaries', function() {
     document.body.innerHTML = __html__['postorder-tree.html'];
-    const walker = document.createTreeWalker(document.getElementById('i'));
+    const walker = document.createTreeWalker(document.getElementById('l'));
     walker.currentNode = document.getElementById('b').firstChild;
-    const visited = utils.forTesting.createOverrideMap(walker);
+    const override = utils.forTesting.createForwardOverrideMap(walker);
     const traversalOrder = [];
-    while (utils.forTesting.forwardTraverse(walker, visited) != null) {
+    while (utils.forTesting.forwardTraverse(walker, override) != null) {
       if (walker.currentNode.id != null) {
         traversalOrder.push(walker.currentNode.id);
       }
     }
-    expect(traversalOrder).toEqual(['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
+    expect(traversalOrder).toEqual([
+      'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'
+    ]);
+  });
+
+  it('can traverse in reverse order for finding block boundaries', function() {
+    document.body.innerHTML = __html__['postorder-tree.html'];
+    const walker = document.createTreeWalker(document.getElementById('l'));
+    const origin = document.getElementById('k').firstChild;
+    walker.currentNode = origin;
+    const visited = new Set();
+    const traversalOrder = [];
+    while (utils.forTesting.backwardTraverse(walker, visited, origin) != null) {
+      if (walker.currentNode.id != null) {
+        traversalOrder.push(walker.currentNode.id);
+      }
+    }
+    expect(traversalOrder).toEqual([
+      'k', 'j', 'h', 'i', 'g', 'f', 'c', 'e', 'd', 'b', 'l'
+    ]);
   });
 });

--- a/test/postorder-tree.html
+++ b/test/postorder-tree.html
@@ -1,12 +1,17 @@
-<div id="i">
-  <div id="d">
+<div id="l">
+  <div id="f">
     <div id="b">a</div>
-    <div id="c"></div>
+    <div id="c">
+      <div id="d"></div>
+      <div id="e"></div>
+    </div>
   </div>
-  <div id="e">
-    <div id="f"></div>
-    <div id="g">
-      <div id="h"></div>
+  <div id="g">
+    <div id="h">
+      <div id="i"></div>
+    </div>
+    <div id="j">
+      <div id="k">z</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds a `backwardTraverse` which serves a similar purpose to the existing `forwardTraverse`, though the implementation is quite different. It will make existing block detection (for when we need to expand the range) more accurate in edge cases, and will be needed for the next patch, which generates the search space for range matching.