### PR TITLE
Adding support for range matches in block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "src/text-fragments.js",
   "browser": "src/text-fragments.js",

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -62,6 +62,21 @@ describe('FragmentGenerationUtils', function() {
     expect(result.fragment.suffix).toBeUndefined();
   });
 
+  it('can generate a fragment for a really long range in a text node.',
+     function() {
+       document.body.innerHTML = __html__['very-long-text.html'];
+       const range = document.createRange();
+       range.selectNodeContents(document.getElementById('root'));
+
+       const selection = window.getSelection();
+       selection.removeAllRanges();
+       selection.addRange(range);
+
+       const result = generationUtils.generateFragment(selection);
+       expect(result.fragment.textStart).toEqual('words words words');
+       expect(result.fragment.textEnd).toEqual('words words words');
+     });
+
   it('can detect if a range contains a block boundary', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     const range = document.createRange();
@@ -339,7 +354,7 @@ describe('FragmentGenerationUtils', function() {
         .toEqual('div with lots of different stuff');
   });
 
-  it('can generate progressively larger fragments for a range', function() {
+  it('can generate progressively larger fragments across blocks', function() {
     document.body.innerHTML = __html__['range-fragment-test.html'];
     const range = document.createRange();
     range.selectNodeContents(document.getElementById('root'));
@@ -390,6 +405,29 @@ describe('FragmentGenerationUtils', function() {
 
     expect(factory.embiggen()).toEqual(true);
     expect(factory.embiggen()).toEqual(true);
+    expect(factory.embiggen()).toEqual(false);
+  });
+
+  it('can generate progressively larger fragments within a block', function() {
+    const sharedSpace = 'text1 text2 text3 text4 text5 text6 text7';
+
+    const factory = new generationUtils.forTesting.FragmentFactory(sharedSpace);
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset)).toEqual('text1');
+    expect(sharedSpace.substring(factory.endOffset)).toEqual('text7');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2');
+    expect(sharedSpace.substring(factory.endOffset)).toEqual('text6 text7');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2 text3');
+    expect(sharedSpace.substring(factory.endOffset))
+        .toEqual('text5 text6 text7');
+
     expect(factory.embiggen()).toEqual(false);
   });
 });

--- a/test/very-long-text.html
+++ b/test/very-long-text.html
@@ -1,0 +1,5 @@
+<p id="root">
+  words words words so many words
+  looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+  textnode is long words words words
+</p>


### PR DESCRIPTION
This patch adds support for range matching within a block, which can be invoked for very long text selections (300+ char) that don't cross block boundaries.

Since this completes the range matching functionality (except bug fixes, tech debt, etc.), this also includes a version bump to 2.0.0.