### PR TITLE
Fixed boundary chars at fragment's ends

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -739,8 +739,8 @@ const isWordBounded = (text, startPos, length) => {
     return false;
   }
 
-  // Move startPos until it does not point on a boundary character.
-  while (text[startPos].match(BOUNDARY_CHARS)) {
+  // If the first character is already a boundary, move it once.
+  if (text[startPos].match(BOUNDARY_CHARS)) {
     ++startPos;
     --length;
     if (!length) {
@@ -748,15 +748,15 @@ const isWordBounded = (text, startPos, length) => {
     }
   }
 
-  // Move end character until it does not point on a boundary character.
-  while(text[startPos + length - 1].match(BOUNDARY_CHARS)) {
+  // If the last character is already a boundary, move it once.
+  if (text[startPos + length - 1].match(BOUNDARY_CHARS)) {
     --length;
     if (!length) {
       return false;
     }
   }
 
-  if (startPos !== 0 && !text[startPos - 1].match(BOUNDARY_CHARS)) return false;
+  if (startPos !== 0 && (!text[startPos - 1].match(BOUNDARY_CHARS))) return false;
 
   if (startPos + length !== text.length &&
       !text[startPos + length].match(BOUNDARY_CHARS))

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -739,6 +739,23 @@ const isWordBounded = (text, startPos, length) => {
     return false;
   }
 
+  // Move startPos until it does not point on a boundary character.
+  while (text[startPos].match(BOUNDARY_CHARS)) {
+    ++startPos;
+    --length;
+    if (!length) {
+      return false;
+    }
+  }
+
+  // Move end character until it does not point on a boundary character.
+  while(text[startPos + length - 1].match(BOUNDARY_CHARS)) {
+    --length;
+    if (!length) {
+      return false;
+    }
+  }
+
   if (startPos !== 0 && !text[startPos - 1].match(BOUNDARY_CHARS)) return false;
 
   if (startPos + length !== text.length &&

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -348,6 +348,9 @@ describe('TextFragmentUtils', function() {
       {data: 'the quick, brown dog', substring: 'the quick'},
       {data: 'a "quotation" works', substring: 'quotation'},
       {data: 'other\nspacing\t', substring: 'spacing'},
+      {data: 'text foo bar', substring: 'foo '},
+      {data: 'text foo bar', substring: ' foo'},
+      {data: 'text foo bar', substring: ' foo '},
       // Japanese has no spaces, so only punctuation works as a boundary.
       {data: 'はい。いいえ。', substring: 'いいえ'},
       {data: '『パープル・レイン』', substring: 'パープル'},
@@ -357,6 +360,8 @@ describe('TextFragmentUtils', function() {
       {data: 'testing', substring: 'test'},
       {data: 'attest', substring: 'test'},
       {data: 'untested', substring: 'test'},
+      {data: '  hello ', substring: '  '},
+      {data: ' hello  ', substring: '  '},
       // アルバム is an actual word. With proper Japanese word segmenting we
       // could move this to the true cases, but for now we expect it to be
       // rejected.

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -349,7 +349,7 @@ describe('TextFragmentUtils', function() {
       {data: 'a "quotation" works', substring: 'quotation'},
       {data: 'other\nspacing\t', substring: 'spacing'},
       {data: 'text foo bar', substring: 'foo '},
-      {data: 'text foo bar', substring: ' foo'},
+      {data: 'text  foo bar', substring: '  foo'},
       {data: 'text foo bar', substring: ' foo '},
       // Japanese has no spaces, so only punctuation works as a boundary.
       {data: 'はい。いいえ。', substring: 'いいえ'},


### PR DESCRIPTION
This allows scrolling to fragments which have boundary characters at the beginning or end of the fragment.