### PR TITLE
Remove unreachable return statement

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -96,7 +96,6 @@ export const generateFragment = (selection) => {
     // TODO: Add context here.
     return {status: GenerateFragmentStatus.AMBIGUOUS};
   }
-  return {status: GenerateFragmentStatus.INVALID_SELECTION};
 };
 
 /**


### PR DESCRIPTION
The return {status: GenerateFragmentStatus.INVALID_SELECTION}; could never be reached.