### PR TITLE
Refactoring range matching to prepare for context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -756,7 +756,8 @@ const isWordBounded = (text, startPos, length) => {
     }
   }
 
-  if (startPos !== 0 && (!text[startPos - 1].match(BOUNDARY_CHARS))) return false;
+  if (startPos !== 0 && (!text[startPos - 1].match(BOUNDARY_CHARS)))
+    return false;
 
   if (startPos + length !== text.length &&
       !text[startPos + length].match(BOUNDARY_CHARS))

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -428,6 +428,12 @@ describe('FragmentGenerationUtils', function() {
     expect(sharedSpace.substring(factory.endOffset))
         .toEqual('text5 text6 text7');
 
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2 text3 text4');
+    expect(sharedSpace.substring(factory.endOffset))
+        .toEqual(' text5 text6 text7');
+
     expect(factory.embiggen()).toEqual(false);
   });
 });


### PR DESCRIPTION
This patch slightly refactors range-based matching, achieving two
things:

* Making it slightly more robust (see the diff in the test to see
  the affected case)

* Collecting the state that will determine if/when to use context
  in a subsequent patch