### PR TITLE
Adding context logic to FragmentFactory

### DIFF
--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -436,4 +436,59 @@ describe('FragmentGenerationUtils', function() {
 
     expect(factory.embiggen()).toEqual(false);
   });
+
+  it('can add context to a single-block range match', function() {
+    const sharedSpace = 'text1 text2 text3 text4 text5 text6 text7';
+    const prefixSpace = 'prefix3 prefix2 prefix1';
+    const suffixSpace = 'suffix1 suffix2 suffix3';
+
+    const factory = new generationUtils.forTesting.FragmentFactory(sharedSpace);
+    factory.setPrefixSearchSpace(prefixSpace);
+    factory.setSuffixSearchSpace(suffixSpace);
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset)).toEqual('text1');
+    expect(sharedSpace.substring(factory.endOffset)).toEqual('text7');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2');
+    expect(sharedSpace.substring(factory.endOffset)).toEqual('text6 text7');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2 text3');
+    expect(sharedSpace.substring(factory.endOffset))
+        .toEqual('text5 text6 text7');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2 text3 text4');
+    expect(sharedSpace.substring(factory.endOffset))
+        .toEqual(' text5 text6 text7');
+    expect(prefixSpace.substring(factory.prefixOffset)).toEqual('prefix1');
+    expect(suffixSpace.substring(0, factory.suffixOffset)).toEqual('suffix1');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2 text3 text4');
+    expect(sharedSpace.substring(factory.endOffset))
+        .toEqual(' text5 text6 text7');
+    expect(prefixSpace.substring(factory.prefixOffset))
+        .toEqual('prefix2 prefix1');
+    expect(suffixSpace.substring(0, factory.suffixOffset))
+        .toEqual('suffix1 suffix2');
+
+    expect(factory.embiggen()).toEqual(true);
+    expect(sharedSpace.substring(0, factory.startOffset))
+        .toEqual('text1 text2 text3 text4');
+    expect(sharedSpace.substring(factory.endOffset))
+        .toEqual(' text5 text6 text7');
+    expect(prefixSpace.substring(factory.prefixOffset))
+        .toEqual('prefix3 prefix2 prefix1');
+    expect(suffixSpace.substring(0, factory.suffixOffset))
+        .toEqual('suffix1 suffix2 suffix3');
+
+    expect(factory.embiggen()).toEqual(false);
+  });
 });


### PR DESCRIPTION
This adds the first chunk of the context (prefix/suffix) match generation logic to the FragmentFactory.

This is not currently on the critical path; only in test. A follow-up patch will actually *generate* the search space, and pass it to the factory. The factory constructor will get reworked a bit at that time, but I didn't want this to be a breaking change for the current critical path, so the current (temp) implementation is just optional setters.