### PR TITLE
Optimize ambiguous match checking

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -147,6 +147,10 @@ export const processTextFragmentDirective = (textFragment) => {
   searchRange.selectNodeContents(document.body);
 
   while (!searchRange.collapsed) {
+    if (results.length > 1) {
+      return results;
+    }
+
     let potentialMatch;
     if (textFragment.prefix) {
       const prefixMatch = findTextInRange(textFragment.prefix, searchRange);
@@ -211,6 +215,10 @@ export const processTextFragmentDirective = (textFragment) => {
       // Search through the rest of the document to find a textEnd match. This
       // may take multiple iterations if a suffix needs to be found.
       while (!textEndRange.collapsed) {
+        if (results.length > 1) {
+          return results;
+        }
+
         const textEndMatch =
             findTextInRange(textFragment.textEnd, textEndRange);
         if (textEndMatch == null) {
@@ -232,9 +240,6 @@ export const processTextFragmentDirective = (textFragment) => {
             break;
           } else if (suffixResult === CheckSuffixResult.SUFFIX_MATCH) {
             results.push(potentialMatch.cloneRange());
-            if (results.length > 1) {
-              return results;
-            }
             continue;
           } else if (suffixResult === CheckSuffixResult.MISPLACED_SUFFIX) {
             continue;
@@ -242,9 +247,6 @@ export const processTextFragmentDirective = (textFragment) => {
         } else {
           // If we've found textEnd and there's no suffix, then it's a match!
           results.push(potentialMatch.cloneRange());
-          if (results.length > 1) {
-            return results;
-          }
         }
       }
     } else if (textFragment.suffix) {
@@ -256,9 +258,6 @@ export const processTextFragmentDirective = (textFragment) => {
         break;
       } else if (suffixResult === CheckSuffixResult.SUFFIX_MATCH) {
         results.push(potentialMatch.cloneRange());
-        if (results.length > 1) {
-          return results;
-        }
         advanceRangeStartPastOffset(
             searchRange, searchRange.startContainer, searchRange.startOffset);
         continue;
@@ -267,9 +266,6 @@ export const processTextFragmentDirective = (textFragment) => {
       }
     } else {
       results.push(potentialMatch.cloneRange());
-      if (results.length > 1) {
-        return results;
-      }
     }
   }
   return results;

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -135,8 +135,10 @@ export const processFragmentDirectives = (parsedFragmentDirectives) => {
  *
  * @param {TextFragment} textFragment - Text Fragment to highlight.
  * @return {Ranges[]} - Zero or more ranges within the document corresponding
- *     to the fragment. The fragment uniquely identifies a section of the page
- *     iff the returned list has length 1
+ *     to the fragment. If the fragment corresponds to more than one location
+ *     in the document (i.e., is ambiguous) then the first two matches will be
+ *     returned (regardless of how many more matches there may be in the
+ *     document).
  */
 export const processTextFragmentDirective = (textFragment) => {
   const results = [];
@@ -230,6 +232,9 @@ export const processTextFragmentDirective = (textFragment) => {
             break;
           } else if (suffixResult === CheckSuffixResult.SUFFIX_MATCH) {
             results.push(potentialMatch.cloneRange());
+            if (results.length > 1) {
+              return results;
+            }
             continue;
           } else if (suffixResult === CheckSuffixResult.MISPLACED_SUFFIX) {
             continue;
@@ -237,6 +242,9 @@ export const processTextFragmentDirective = (textFragment) => {
         } else {
           // If we've found textEnd and there's no suffix, then it's a match!
           results.push(potentialMatch.cloneRange());
+          if (results.length > 1) {
+            return results;
+          }
         }
       }
     } else if (textFragment.suffix) {
@@ -248,6 +256,9 @@ export const processTextFragmentDirective = (textFragment) => {
         break;
       } else if (suffixResult === CheckSuffixResult.SUFFIX_MATCH) {
         results.push(potentialMatch.cloneRange());
+        if (results.length > 1) {
+          return results;
+        }
         advanceRangeStartPastOffset(
             searchRange, searchRange.startContainer, searchRange.startOffset);
         continue;
@@ -256,6 +267,9 @@ export const processTextFragmentDirective = (textFragment) => {
       }
     } else {
       results.push(potentialMatch.cloneRange());
+      if (results.length > 1) {
+        return results;
+      }
     }
   }
   return results;

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -146,11 +146,7 @@ export const processTextFragmentDirective = (textFragment) => {
   const searchRange = document.createRange();
   searchRange.selectNodeContents(document.body);
 
-  while (!searchRange.collapsed) {
-    if (results.length > 1) {
-      return results;
-    }
-
+  while (!searchRange.collapsed && results.length < 2) {
     let potentialMatch;
     if (textFragment.prefix) {
       const prefixMatch = findTextInRange(textFragment.prefix, searchRange);
@@ -214,11 +210,7 @@ export const processTextFragmentDirective = (textFragment) => {
 
       // Search through the rest of the document to find a textEnd match. This
       // may take multiple iterations if a suffix needs to be found.
-      while (!textEndRange.collapsed) {
-        if (results.length > 1) {
-          return results;
-        }
-
+      while (!textEndRange.collapsed && results.length < 2) {
         const textEndMatch =
             findTextInRange(textFragment.textEnd, textEndRange);
         if (textEndMatch == null) {

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -404,13 +404,13 @@ describe('TextFragmentUtils', function() {
     }
   });
 
-  it('finds all instances of ambiguous fragments', function() {
+  it('finds multiple instances of ambiguous fragments', function() {
     document.body.innerHTML = __html__['ambiguous-match.html'];
 
     // Simplest case: textStart which appears multiple times
     let fragment = utils.forTesting.parseTextFragmentDirective('target');
     let result = utils.processTextFragmentDirective(fragment);
-    expect(result.length).toEqual(4);
+    expect(result.length).toEqual(2);
 
     // prefix + textStart
     fragment = utils.forTesting.parseTextFragmentDirective('prefix1-,target');
@@ -422,29 +422,25 @@ describe('TextFragmentUtils', function() {
     result = utils.processTextFragmentDirective(fragment);
     expect(result.length).toEqual(2);
 
-    // Repeated textStart + textEnd creates lots of combinations; with 4
-    // instances, we get (4 choose 2) = 6.
+    // textStart + textEnd
     fragment = utils.forTesting.parseTextFragmentDirective('target,target');
     result = utils.processTextFragmentDirective(fragment);
-    expect(result.length).toEqual(6);
+    expect(result.length).toEqual(2);
 
-    // First instance of "prefix1 target" can match with 3 other "target"s;
-    // second instance of "prefix1 target" can match with 1 other "target", for
-    // a total of 4.
+
+    // prefix, textStart, + textEnd
     fragment =
         utils.forTesting.parseTextFragmentDirective('prefix1-,target,target');
     result = utils.processTextFragmentDirective(fragment);
-    expect(result.length).toEqual(4);
+    expect(result.length).toEqual(2);
 
-    // First instance of "target" can match with 2 "target suffix2"s; second
-    // instance of "target" can match 1, for a total of 3.
+    // textStart, textEnd, + suffix
     fragment =
         utils.forTesting.parseTextFragmentDirective('target,target,-suffix2');
     result = utils.processTextFragmentDirective(fragment);
-    expect(result.length).toEqual(3);
+    expect(result.length).toEqual(2);
 
-    // Two instances of "prefix1 target" can each match with one
-    // "target suffix2"
+    // all parts
     fragment = utils.forTesting.parseTextFragmentDirective(
         'prefix1-,target,target,-suffix2');
     result = utils.processTextFragmentDirective(fragment);


### PR DESCRIPTION
Currently, we search for *every* location in the document matching
the fragment; this, in turn, is making URL generation timeout in
Chrome. We only really need to find 2 instances to know that a
fragment is ambiguous, so this patch halts the search after 2 are
found.