### PR TITLE
Improve table support

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -28,12 +28,13 @@ const FRAGMENT_DIRECTIVES = ['text'];
 // block element. Source for the list:
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#Elements
 const BLOCK_ELEMENTS = [
-  'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'DETAILS',  'DIALOG',
-  'DD',      'DIV',     'DL',    'DT',         'FIELDSET', 'FIGCAPTION',
-  'FIGURE',  'FOOTER',  'FORM',  'H1',         'H2',       'H3',
-  'H4',      'H5',      'H6',    'HEADER',     'HGROUP',   'HR',
-  'LI',      'MAIN',    'NAV',   'OL',         'P',        'PRE',
-  'SECTION', 'TABLE',   'UL',
+  'ADDRESS',  'ARTICLE', 'ASIDE',   'BLOCKQUOTE', 'DETAILS',  'DIALOG',
+  'DD',       'DIV',     'DL',      'DT',         'FIELDSET', 'FIGCAPTION',
+  'FIGURE',   'FOOTER',  'FORM',    'H1',         'H2',       'H3',
+  'H4',       'H5',      'H6',      'HEADER',     'HGROUP',   'HR',
+  'LI',       'MAIN',    'NAV',     'OL',         'P',        'PRE',
+  'SECTION',  'TABLE',   'UL',      'TR',         'TH',       'TD',
+  'COLGROUP', 'COL',     'CAPTION', 'THEAD',      'TBODY',    'TFOOT',
 ];
 
 // Characters that indicate a word boundary. Use the script

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -578,4 +578,35 @@ describe('FragmentGenerationUtils', function() {
     expect(fragmentUtils.forTesting.normalizeString(result.fragment.suffix))
         .toEqual('recteque qui ei. suffix');
   });
+
+  it('can generate URLs spanning table elements', function() {
+    document.body.innerHTML = __html__['table.html'];
+
+    const target = document.createRange();
+    const selection = window.getSelection();
+
+    const nodeA = document.getElementById('a').firstChild;
+    target.setStart(nodeA, 6);
+    target.setEnd(nodeA, 11);
+    selection.removeAllRanges();
+    selection.addRange(target);
+
+    let result = generationUtils.generateFragment(selection);
+    expect(fragmentUtils.forTesting.normalizeString(result.fragment.prefix))
+        .toEqual('first');
+    expect(fragmentUtils.forTesting.normalizeString(result.fragment.textStart))
+        .toEqual('named');
+
+    const nodeB = document.getElementById('b').firstChild;
+    target.setStart(nodeA, 0);
+    target.setEnd(nodeB, nodeB.textContent.length);
+    selection.removeAllRanges();
+    selection.addRange(target);
+
+    result = generationUtils.generateFragment(selection);
+    expect(fragmentUtils.forTesting.normalizeString(result.fragment.textStart))
+        .toEqual('first named');
+    expect(fragmentUtils.forTesting.normalizeString(result.fragment.textEnd))
+        .toEqual('2014');
+  });
 });

--- a/test/table.html
+++ b/test/table.html
@@ -1,0 +1,28 @@
+<table>
+  <tbody>
+    <tr>
+      <th rowspan="2">Name</th>
+      <th rowspan="2">Number</th>
+      <th colspan="3">Some dates</th>
+    </tr>
+    <tr>
+      <th>First date</th>
+      <th>Second date</th>
+      <th>Third date</th>
+    </tr>
+    <tr>
+      <td id="a">First named entity</td>
+      <td style="text-align: center">12</td>
+      <td>May 11, 2011</td>
+      <td>February 6, 2012 (note)</td>
+      <td id="b">June 3, 2014</td>
+    </tr>
+    <tr>
+      <td>Other named entity</td>
+      <td style="text-align: center">20</td>
+      <td>October 18, 2004</td>
+      <td>July 6, 2005 (other note)</td>
+      <td>September 30, 2009</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -446,4 +446,16 @@ describe('TextFragmentUtils', function() {
     result = utils.processTextFragmentDirective(fragment);
     expect(result.length).toEqual(2);
   });
+
+  it('can find ranges spanning multiple table elements', function() {
+    document.body.innerHTML = __html__['table.html'];
+    let fragment =
+        utils.forTesting.parseTextFragmentDirective('First%20named,2014');
+    let result = utils.processTextFragmentDirective(fragment);
+    expect(result.length).toEqual(1);
+
+    fragment = utils.forTesting.parseTextFragmentDirective('12');
+    result = utils.processTextFragmentDirective(fragment);
+    expect(result.length).toEqual(1);
+  });
 });


### PR DESCRIPTION
This patch adds table-related elements (tr, td, etc.) as block
elements, which seems to improve reliability and robustness in
real-world usage.