### PR TITLE
Support ::target-text background-color lookup

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -820,3 +820,24 @@ if (typeof goog !== 'undefined') {
   goog.declareModuleId('googleChromeLabs.textFragmentPolyfill.textFragmentUtils');
   // clang-format on
 }
+
+/**
+ * Seaches ::target-text background color in the document
+ *
+ * @return {string} - background color from ::target-text
+ */
+export const getTargetTextBackgroundColor = () => {
+  const styles = document.getElementsByTagName("style");
+  if (!styles) return null;
+
+  for (const style of styles) {
+    const cssRules = style.innerHTML;
+    const targetTextRules = cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
+    if (!targetTextRules) return null;
+
+    const backgroundColor = targetTextRules[0].match(/background-color\s*:\s*(.*?)\s*;/);
+    if (!backgroundColor) return null;
+    
+    return backgroundColor[1];
+  }
+}

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -822,22 +822,46 @@ if (typeof goog !== 'undefined') {
 }
 
 /**
- * Seaches ::target-text background color in the document
+ * Extract color and background-color from ::target-text in the document.
  *
- * @return {string} - background color from ::target-text
+ * @return {{backgroundColor: string, color: string}} - color and background-color from ::target-text
  */
-export const getTargetTextBackgroundColor = () => {
+export const getTargetTextStyle = () => {
+  
   const styles = document.getElementsByTagName("style");
   if (!styles) return null;
 
   for (const style of styles) {
     const cssRules = style.innerHTML;
     const targetTextRules = cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
-    if (!targetTextRules) return null;
+    if (!targetTextRules) continue;
 
     const backgroundColor = targetTextRules[0].match(/background-color\s*:\s*(.*?)\s*;/);
-    if (!backgroundColor) return null;
-    
-    return backgroundColor[1];
+    const color = targetTextRules[0].match(/[^-]color\s*:\s*(.*?)\s*;/);
+
+    const targetTextStyle = {
+      backgroundColor: isValidColor(backgroundColor) ? backgroundColor[1] : null,
+      color: isValidColor(color) ? color[1] : null
+    };
+
+    return targetTextStyle;
   }
+
+  return null;
 }
+
+/**
+ * Verify that the regex match is a valid color.
+ * 
+ * @param {String} color - regex match to be validated
+ * @return {bool} - true iff the regex match is a valid color.
+ */
+const isValidColor = (color) => {
+  if (!color) return false;
+  if (color.length < 2) return false;
+
+  const optionElement = new Option().style;
+  optionElement.color = color[1].replace('!important', '');
+
+  return optionElement.color === null ? false : true;
+};

--- a/test/target-text-test.html
+++ b/test/target-text-test.html
@@ -1,0 +1,16 @@
+<style type="text/css">
+    ::target-text {
+      background-color: green;
+    }
+</style>
+<div id="a">
+    This is
+    <p id="b">
+      a really <i id="c">elab<span id="d">or</span>ate</i>
+    </p>
+    <p id="e">fancy</p>
+    div with
+    <b id="f">lots of different stuff</b>
+    in it.
+  </div>
+  

--- a/test/target-text-test.html
+++ b/test/target-text-test.html
@@ -1,5 +1,6 @@
 <style type="text/css">
     ::target-text {
+      color: grey !important;
       background-color: green;
     }
 </style>

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -458,4 +458,15 @@ describe('TextFragmentUtils', function() {
     result = utils.processTextFragmentDirective(fragment);
     expect(result.length).toEqual(1);
   });
+
+  it("finds the background color from ::target-text", function() {
+    document.body.innerHTML = __html__['target-text-test.html'];
+    var backgroundColor = utils.getTargetTextBackgroundColor();
+    expect(backgroundColor).toEqual("green");
+
+    document.body.innerHTML = __html__['marks_test.html'];
+    backgroundColor = utils.getTargetTextBackgroundColor();
+    expect(backgroundColor).toBeUndefined;
+    
+  });
 });

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -461,12 +461,37 @@ describe('TextFragmentUtils', function() {
 
   it("finds the background color from ::target-text", function() {
     document.body.innerHTML = __html__['target-text-test.html'];
-    var backgroundColor = utils.getTargetTextBackgroundColor();
-    expect(backgroundColor).toEqual("green");
 
+    // complete ::target-text
+    var targetTextStyle = utils.getTargetTextStyle();
+    expect(targetTextStyle.backgroundColor).toEqual("green");
+    expect(targetTextStyle.color).toEqual("grey !important");
+
+    // wrong background color
+    document.getElementsByTagName('style')[0].innerHTML = `
+      ::target-text {
+        color: #FFC0CB;
+        background-color: wrong;
+      }
+    `; 
+    targetTextStyle = utils.getTargetTextStyle();
+    expect(targetTextStyle.color).toEqual("#FFC0CB");
+    expect(targetTextStyle.backgroundColor).toBeUndefined;
+
+    // no color
+    document.getElementsByTagName('style')[0].innerHTML = `
+      ::target-text {
+        background-color: rgb(230, 230, 250);
+      }
+    `; 
+    targetTextStyle = utils.getTargetTextStyle();
+    expect(targetTextStyle.backgroundColor).toEqual("rgb(230, 230, 250)");
+    expect(targetTextStyle.color).toBeUndefined;
+
+    // no ::target-text
     document.body.innerHTML = __html__['marks_test.html'];
-    backgroundColor = utils.getTargetTextBackgroundColor();
-    expect(backgroundColor).toBeUndefined;
+    targetTextStyle = utils.getTargetTextStyle();
+    expect(targetTextStyle).toBeUndefined;
     
   });
 });


### PR DESCRIPTION
## Changes

Lookup ::target-text background-color

This PR allow the lookup of the pseudo element `::target-text` background color responsible for styling the Text Fragment. 