### PR TITLE
Update text-fragments to reflect style changes

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -873,6 +873,9 @@ const isValidColor = (color) => {
  * @param {Object} - background-color and color that will be applied to the element style
  */
 export const setMarkStyle = (mark, {backgroundColor, color}) => {
-  if (backgroundColor) mark.style.backgroundColor = backgroundColor;
-  if (color) mark.style.color = color;
+  const cssRuleBackgroundColor = backgroundColor ? `background-color: ${backgroundColor};` : '';
+  const cssRuleColor = color ? `color: ${color};` : '';
+  mark.setAttribute('style', `${cssRuleBackgroundColor && cssRuleColor ?
+                                  cssRuleBackgroundColor + ' ' + cssRuleColor :
+                                  (cssRuleBackgroundColor || cssRuleColor)}`);
 };

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -824,35 +824,39 @@ if (typeof goog !== 'undefined') {
 /**
  * Extract color and background-color from ::target-text in the document.
  *
- * @return {{backgroundColor: string, color: string}} - color and background-color from ::target-text
+ * @return {{backgroundColor: string, color: string}} - color and
+ *     background-color from ::target-text
  */
-export const getTargetTextStyle = () => {
-  
-  const styles = document.getElementsByTagName("style");
-  if (!styles) return null;
+export const getTargetTextStyle =
+    () => {
+      const styles = document.getElementsByTagName('style');
+      if (!styles) return null;
 
-  for (const style of styles) {
-    const cssRules = style.innerHTML;
-    const targetTextRules = cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
-    if (!targetTextRules) continue;
+      for (const style of styles) {
+        const cssRules = style.innerHTML;
+        const targetTextRules =
+            cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
+        if (!targetTextRules) continue;
 
-    const backgroundColor = targetTextRules[0].match(/background-color\s*:\s*(.*?)\s*;/);
-    const color = targetTextRules[0].match(/[^-]color\s*:\s*(.*?)\s*;/);
+        const backgroundColor =
+            targetTextRules[0].match(/background-color\s*:\s*(.*?)\s*;/);
+        const color = targetTextRules[0].match(/[^-]color\s*:\s*(.*?)\s*;/);
 
-    const targetTextStyle = {
-      backgroundColor: isValidColor(backgroundColor) ? backgroundColor[1] : null,
-      color: isValidColor(color) ? color[1] : null
-    };
+        const targetTextStyle = {
+          backgroundColor: isValidColor(backgroundColor) ? backgroundColor[1] :
+                                                           null,
+          color: isValidColor(color) ? color[1] : null
+        };
 
-    return targetTextStyle;
-  }
+        return targetTextStyle;
+      }
 
-  return null;
-}
+      return null;
+    }
 
 /**
  * Verify that the regex match is a valid color.
- * 
+ *
  * @param {String} color - regex match to be validated
  * @return {bool} - true iff the regex match is a valid color.
  */
@@ -868,14 +872,19 @@ const isValidColor = (color) => {
 
 /**
  * Add color and background-color to <mark> tag.
- * 
+ *
  * @param {Object} mark - <mark> element to receive inline style
- * @param {Object} - background-color and color that will be applied to the element style
+ * @param {Object} - background-color and color that will be applied to the
+ *     element style
  */
 export const setMarkStyle = (mark, {backgroundColor, color}) => {
-  const cssRuleBackgroundColor = backgroundColor ? `background-color: ${backgroundColor};` : '';
+  const cssRuleBackgroundColor =
+      backgroundColor ? `background-color: ${backgroundColor};` : '';
   const cssRuleColor = color ? `color: ${color};` : '';
-  mark.setAttribute('style', `${cssRuleBackgroundColor && cssRuleColor ?
-                                  cssRuleBackgroundColor + ' ' + cssRuleColor :
-                                  (cssRuleBackgroundColor || cssRuleColor)}`);
+  mark.setAttribute(
+      'style',
+      `${
+          cssRuleBackgroundColor && cssRuleColor ?
+              cssRuleBackgroundColor + ' ' + cssRuleColor :
+              (cssRuleBackgroundColor || cssRuleColor)}`);
 };

--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -39,20 +39,10 @@ import * as utils from './text-fragment-utils.js';
     const createdMarks = processedFragmentDirectives['text'];
 
     const targetTextStyle = utils.getTargetTextStyle();
-    const markStyle = {
-      backgroundColor: targetTextStyle && targetTextStyle.backgroundColor ?
-                        (targetTextStyle.backgroundColor.includes('!important') ?
-                          targetTextStyle.backgroundColor :
-                          targetTextStyle.backgroundColor + ' !important') :
-                        'rgb(233,210,253) !important',
-      color: targetTextStyle && targetTextStyle.color ?
-              (targetTextStyle.color.includes('!important') ?
-                targetTextStyle.color :
-                targetTextStyle.color + ' !important') :
-              null
-    };
-    for (const createdMark of createdMarks) {
-      utils.setMarkStyle(createdMark[0], markStyle);
+    if (targetTextStyle) {
+      for (const createdMark of createdMarks.flat()) {
+        utils.setMarkStyle(createdMark, targetTextStyle);
+      }
     }
 
     const firstFoundMatch = createdMarks.find((marks) => marks.length)[0];

--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -37,6 +37,24 @@ import * as utils from './text-fragment-utils.js';
         parsedFragmentDirectives,
     );
     const createdMarks = processedFragmentDirectives['text'];
+
+    const targetTextStyle = utils.getTargetTextStyle();
+    const markStyle = {
+      backgroundColor: targetTextStyle && targetTextStyle.backgroundColor ?
+                        (targetTextStyle.backgroundColor.includes('!important') ?
+                          targetTextStyle.backgroundColor :
+                          targetTextStyle.backgroundColor + ' !important') :
+                        'rgb(233,210,253) !important',
+      color: targetTextStyle && targetTextStyle.color ?
+              (targetTextStyle.color.includes('!important') ?
+                targetTextStyle.color :
+                targetTextStyle.color + ' !important') :
+              null
+    };
+    for (const createdMark of createdMarks) {
+      utils.setMarkStyle(createdMark[0], markStyle);
+    }
+
     const firstFoundMatch = createdMarks.find((marks) => marks.length)[0];
     if (firstFoundMatch) {
       window.setTimeout(() => utils.scrollElementIntoView(firstFoundMatch));

--- a/test/target-text-test.html
+++ b/test/target-text-test.html
@@ -1,17 +1,16 @@
 <style type="text/css">
-    ::target-text {
-      color: grey !important;
-      background-color: green;
-    }
+  ::target-text {
+    color: grey !important;
+    background-color: green;
+  }
 </style>
 <div id="a">
-    This is
-    <p id="b">
-      a really <i id="c">elab<span id="d">or</span>ate</i>
-    </p>
-    <p id="e">fancy</p>
-    div with
-    <b id="f">lots of different stuff</b>
-    in it.
-  </div>
-  
+  This is
+  <p id="b">
+    a really <i id="c">elab<span id="d">or</span>ate</i>
+  </p>
+  <p id="e">fancy</p>
+  div with
+  <b id="f">lots of different stuff</b>
+  in it.
+</div>

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -463,9 +463,9 @@ describe('TextFragmentUtils', function() {
     document.body.innerHTML = __html__['target-text-test.html'];
 
     // complete ::target-text
-    var targetTextStyle = utils.getTargetTextStyle();
-    expect(targetTextStyle.backgroundColor).toEqual("green");
-    expect(targetTextStyle.color).toEqual("grey !important");
+    let targetTextStyle = utils.getTargetTextStyle();
+    expect(targetTextStyle.backgroundColor).toEqual('green');
+    expect(targetTextStyle.color).toEqual('grey !important');
 
     // wrong background color
     document.getElementsByTagName('style')[0].innerHTML = `
@@ -473,7 +473,7 @@ describe('TextFragmentUtils', function() {
         color: #FFC0CB;
         background-color: wrong;
       }
-    `; 
+    `;
     targetTextStyle = utils.getTargetTextStyle();
     expect(targetTextStyle.color).toEqual('#FFC0CB');
     expect(targetTextStyle.backgroundColor).toBeUndefined;
@@ -483,7 +483,7 @@ describe('TextFragmentUtils', function() {
       ::target-text {
         background-color: rgb(230, 230, 250);
       }
-    `; 
+    `;
     targetTextStyle = utils.getTargetTextStyle();
     expect(targetTextStyle.backgroundColor).toEqual('rgb(230, 230, 250)');
     expect(targetTextStyle.color).toBeUndefined;
@@ -492,7 +492,6 @@ describe('TextFragmentUtils', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     targetTextStyle = utils.getTargetTextStyle();
     expect(targetTextStyle).toBeUndefined;
-    
   });
 
   it('should update <mark> style', function() {
@@ -502,15 +501,12 @@ describe('TextFragmentUtils', function() {
     const lastChild = document.getElementById('a').lastChild;
     range.setEnd(lastChild, lastChild.textContent.length);
     const marks = utils.forTesting.markRange(range);
-    const cssRules = {
-      backgroundColor: 'purple',
-      color: 'grey'
-    }
+    const cssRules = {backgroundColor: 'purple', color: 'grey'}
 
     for (const mark of marks) {
       utils.setMarkStyle(mark, cssRules);
-      expect(mark.outerHTML).toContain(`<mark style="background-color: purple; color: grey;">`);
+      expect(mark.outerHTML)
+          .toContain(`<mark style="background-color: purple; color: grey;">`);
     }
-
   });
 });


### PR DESCRIPTION
# Changes

Update text-fragments

This PR changes the default background color of the text fragment to a light purple, which can only be overridden by `::target-text`.