### PR TITLE
Update getTargetTextStyle to replace target-text in the stylesheet wi…

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -400,6 +400,7 @@ export const markRange = (range) => {
   // If the range is entirely within a single node, just surround it.
   if (range.startContainer === range.endContainer) {
     const trivialMark = document.createElement('mark');
+    trivialMark.setAttribute('class', textFragmentCssClassName);
     range.surroundContents(trivialMark);
     return [trivialMark];
   }
@@ -436,6 +437,7 @@ export const markRange = (range) => {
   while (node) {
     if (node.nodeType === Node.TEXT_NODE) {
       const mark = document.createElement('mark');
+      mark.setAttribute('class', textFragmentCssClassName);
       node.parentNode.insertBefore(mark, node);
       mark.appendChild(node);
       marks.push(mark);
@@ -444,8 +446,10 @@ export const markRange = (range) => {
   }
 
   const startMark = document.createElement('mark');
+  startMark.setAttribute('class', textFragmentCssClassName);
   startNodeSubrange.surroundContents(startMark);
   const endMark = document.createElement('mark');
+  endMark.setAttribute('class', textFragmentCssClassName);
   endNodeSubrange.surroundContents(endMark);
 
   return [startMark, ...marks, endMark];
@@ -823,37 +827,28 @@ if (typeof goog !== 'undefined') {
 
 /**
  * Replaces all occurence of the pseudo element ::target-text to a css class
- * chrome-target-text
+ * text-fragments-polyfill-target-text
  *
- * @return {bool} - true iff we can create a css class from
- *     ::target-text
  */
 export const applyTargetTextStyle =
     () => {
       const styles = document.getElementsByTagName('style');
-      if (!styles) return false;
+      if (!styles) return;
 
-      let targetTextStyleFound = false;
       for (const style of styles) {
         const cssRules = style.innerHTML;
         const targetTextRules =
             cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
         if (!targetTextRules) continue;
 
-        const newNode = document.createTextNode(
-            cssRules.replaceAll('::target-text', ' .chrome-target-text'));
-        style.replaceChild(newNode, style.firstChild);
-        targetTextStyleFound = true;
+        const markCss = targetTextRules.join('\n');
+        const newNode = document.createTextNode(markCss.replaceAll(
+            '::target-text', ` .${textFragmentCssClassName}`));
+        style.appendChild(newNode);
       }
-
-      return targetTextStyleFound;
     }
 
 /**
- * Adds chrome-target-text css class to <mark> tag.
- *
- * @param {Object} mark - <mark> element to receive css class
+ * Text fragments CSS class name.
  */
-export const addCssClassToMark = (mark) => {
-  mark.setAttribute('class', 'chrome-target-text');
-};
+export const textFragmentCssClassName = 'text-fragments-polyfill-target-text';

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -48,6 +48,11 @@ const BOUNDARY_CHARS =
 const NON_BOUNDARY_CHARS =
     /[^\t-\r -#%-\*,-\/:;\?@\[-\]_\{\}\x85\xA0\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u1680\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2000-\u200A\u2010-\u2029\u202F-\u2043\u2045-\u2051\u2053-\u205F\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E44\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/u;
 
+/**
+ * Text fragments CSS class name.
+ */
+export const TEXT_FRAGMENT_CSS_CLASS_NAME =
+    'text-fragments-polyfill-target-text';
 
 /**
  * Get all text fragments from a string
@@ -400,7 +405,7 @@ export const markRange = (range) => {
   // If the range is entirely within a single node, just surround it.
   if (range.startContainer === range.endContainer) {
     const trivialMark = document.createElement('mark');
-    trivialMark.setAttribute('class', textFragmentCssClassName);
+    trivialMark.setAttribute('class', TEXT_FRAGMENT_CSS_CLASS_NAME);
     range.surroundContents(trivialMark);
     return [trivialMark];
   }
@@ -437,7 +442,7 @@ export const markRange = (range) => {
   while (node) {
     if (node.nodeType === Node.TEXT_NODE) {
       const mark = document.createElement('mark');
-      mark.setAttribute('class', textFragmentCssClassName);
+      mark.setAttribute('class', TEXT_FRAGMENT_CSS_CLASS_NAME);
       node.parentNode.insertBefore(mark, node);
       mark.appendChild(node);
       marks.push(mark);
@@ -446,10 +451,10 @@ export const markRange = (range) => {
   }
 
   const startMark = document.createElement('mark');
-  startMark.setAttribute('class', textFragmentCssClassName);
+  startMark.setAttribute('class', TEXT_FRAGMENT_CSS_CLASS_NAME);
   startNodeSubrange.surroundContents(startMark);
   const endMark = document.createElement('mark');
-  endMark.setAttribute('class', textFragmentCssClassName);
+  endMark.setAttribute('class', TEXT_FRAGMENT_CSS_CLASS_NAME);
   endNodeSubrange.surroundContents(endMark);
 
   return [startMark, ...marks, endMark];
@@ -838,17 +843,12 @@ export const applyTargetTextStyle =
       for (const style of styles) {
         const cssRules = style.innerHTML;
         const targetTextRules =
-            cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
+            cssRules.match(/(\w*)::target-text\s*{\s*((.|\n)*?)\s*}/g);
         if (!targetTextRules) continue;
 
         const markCss = targetTextRules.join('\n');
         const newNode = document.createTextNode(markCss.replaceAll(
-            '::target-text', ` .${textFragmentCssClassName}`));
+            '::target-text', ` .${TEXT_FRAGMENT_CSS_CLASS_NAME}`));
         style.appendChild(newNode);
       }
-    }
-
-/**
- * Text fragments CSS class name.
- */
-export const textFragmentCssClassName = 'text-fragments-polyfill-target-text';
+    };

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -822,69 +822,38 @@ if (typeof goog !== 'undefined') {
 }
 
 /**
- * Extract color and background-color from ::target-text in the document.
+ * Replaces all occurence of the pseudo element ::target-text to a css class
+ * chrome-target-text
  *
- * @return {{backgroundColor: string, color: string}} - color and
- *     background-color from ::target-text
+ * @return {bool} - true iff we can create a css class from
+ *     ::target-text
  */
-export const getTargetTextStyle =
+export const applyTargetTextStyle =
     () => {
       const styles = document.getElementsByTagName('style');
-      if (!styles) return null;
+      if (!styles) return false;
 
+      let targetTextStyleFound = false;
       for (const style of styles) {
         const cssRules = style.innerHTML;
         const targetTextRules =
             cssRules.match(/::target-text\s*{\s*((.|\n)*?)\s*}/g);
         if (!targetTextRules) continue;
 
-        const backgroundColor =
-            targetTextRules[0].match(/background-color\s*:\s*(.*?)\s*;/);
-        const color = targetTextRules[0].match(/[^-]color\s*:\s*(.*?)\s*;/);
-
-        const targetTextStyle = {
-          backgroundColor: isValidColor(backgroundColor) ? backgroundColor[1] :
-                                                           null,
-          color: isValidColor(color) ? color[1] : null
-        };
-
-        return targetTextStyle;
+        const newNode = document.createTextNode(
+            cssRules.replaceAll('::target-text', ' .chrome-target-text'));
+        style.replaceChild(newNode, style.firstChild);
+        targetTextStyleFound = true;
       }
 
-      return null;
+      return targetTextStyleFound;
     }
 
 /**
- * Verify that the regex match is a valid color.
+ * Adds chrome-target-text css class to <mark> tag.
  *
- * @param {String} color - regex match to be validated
- * @return {bool} - true iff the regex match is a valid color.
+ * @param {Object} mark - <mark> element to receive css class
  */
-const isValidColor = (color) => {
-  if (!color) return false;
-  if (color.length < 2) return false;
-
-  const optionElement = new Option().style;
-  optionElement.color = color[1].replace('!important', '');
-
-  return optionElement.color === null ? false : true;
-};
-
-/**
- * Add color and background-color to <mark> tag.
- *
- * @param {Object} mark - <mark> element to receive inline style
- * @param {Object} - background-color and color that will be applied to the
- *     element style
- */
-export const setMarkStyle = (mark, {backgroundColor, color}) => {
-  const cssRuleBackgroundColor =
-      backgroundColor ? `background-color: ${backgroundColor};` : '';
-  const cssRuleColor = color ? `color: ${color};` : '';
-  mark.setAttribute(
-      'style',
-      `${
-          cssRuleBackgroundColor && cssRuleColor ?
-              cssRuleBackgroundColor + ' ' + cssRuleColor :
-              (cssRuleBackgroundColor || cssRuleColor)}`);
+export const addCssClassToMark = (mark) => {
+  mark.setAttribute('class', 'chrome-target-text');
 };

--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -37,13 +37,7 @@ import * as utils from './text-fragment-utils.js';
         parsedFragmentDirectives,
     );
     const createdMarks = processedFragmentDirectives['text'];
-
-    if (utils.applyTargetTextStyle()) {
-      for (const createdMark of createdMarks.flat()) {
-        utils.addCssClassToMark(createdMark);
-      }
-    }
-
+    utils.applyTargetTextStyle();
     const firstFoundMatch = createdMarks.find((marks) => marks.length)[0];
     if (firstFoundMatch) {
       window.setTimeout(() => utils.scrollElementIntoView(firstFoundMatch));

--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -38,10 +38,9 @@ import * as utils from './text-fragment-utils.js';
     );
     const createdMarks = processedFragmentDirectives['text'];
 
-    const targetTextStyle = utils.getTargetTextStyle();
-    if (targetTextStyle) {
+    if (utils.applyTargetTextStyle()) {
       for (const createdMark of createdMarks.flat()) {
-        utils.setMarkStyle(createdMark, targetTextStyle);
+        utils.addCssClassToMark(createdMark);
       }
     }
 

--- a/test/basic_test.expected.html
+++ b/test/basic_test.expected.html
@@ -1,1 +1,1 @@
-<p>This is a <mark>trivial test of</mark> the marking logic.</p>
+<p>This is a <mark class="text-fragments-polyfill-target-text">trivial test of</mark> the marking logic.</p>

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -490,11 +490,8 @@ describe('TextFragmentUtils', function() {
     expect(targetTextStyle.color).toEqual('grey !important');
 
     // ::target-text scoped to an element
-    document.getElementsByTagName('style')[0].innerHTML = `
-    div::target-text {
-      background-color: rgb(230, 230, 250);
-    }
-    `;
+    document.getElementsByTagName('style')[0].innerHTML = 
+      'div::target-text { background-color: rgb(230, 230, 250);}';
     utils.applyTargetTextStyle();
     targetTextStyle = getColors();
     expect(targetTextStyle.backgroundColor).toEqual('rgb(230, 230, 250)');

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -13,14 +13,14 @@ const marksArrayToString = (marks) => {
 };
 
 // A helper function to extract the color and background color from
-// css class the chrome-target-text.
+// css class the text-fragments-polyfill-target-text.
 const getColors =
     () => {
       const style = document.getElementsByTagName('style')[0];
       if (!style) return null;
 
-      const chromeTargetTextRules =
-          style.innerHTML.match(/.chrome-target-text\s*{\s*((.|\n)*?)\s*}/g);
+      const chromeTargetTextRules = style.innerHTML.match(
+          /.text-fragments-polyfill-target-text\s*{\s*((.|\n)*?)\s*}/g);
       if (!chromeTargetTextRules) return null;
 
       const backgroundColor =
@@ -484,7 +484,7 @@ describe('TextFragmentUtils', function() {
     document.body.innerHTML = __html__['target-text-test.html'];
 
     // complete ::target-text
-    expect(utils.applyTargetTextStyle()).toBeTrue();
+    utils.applyTargetTextStyle();
     let targetTextStyle = getColors();
     expect(targetTextStyle.backgroundColor).toEqual('green');
     expect(targetTextStyle.color).toEqual('grey !important');
@@ -495,30 +495,14 @@ describe('TextFragmentUtils', function() {
       background-color: rgb(230, 230, 250);
     }
     `;
-    expect(utils.applyTargetTextStyle()).toBeTrue();
+    utils.applyTargetTextStyle();
     targetTextStyle = getColors();
     expect(targetTextStyle.backgroundColor).toEqual('rgb(230, 230, 250)');
     expect(targetTextStyle.color).toBeUndefined;
 
     // no ::target-text
     document.body.innerHTML = __html__['marks_test.html'];
-    expect(utils.applyTargetTextStyle()).toBeFalse();
+    utils.applyTargetTextStyle();
     expect(getColors()).toBeUndefined;
-  });
-
-  it('should update <mark> style', function() {
-    document.body.innerHTML = __html__['marks_test.html'];
-    const range = document.createRange();
-    range.setStart(document.getElementById('a').firstChild, 0);
-    const lastChild = document.getElementById('a').lastChild;
-    range.setEnd(lastChild, lastChild.textContent.length);
-    const marks = utils.forTesting.markRange(range);
-    const cssRules = {backgroundColor: 'purple', color: 'grey'}
-
-    for (const mark of marks) {
-      utils.setMarkStyle(mark, cssRules);
-      expect(mark.outerHTML)
-          .toContain(`<mark style="background-color: purple; color: grey;">`);
-    }
   });
 });

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -12,6 +12,27 @@ const marksArrayToString = (marks) => {
   return text.join('').replace(/[\t\n\r ]+/g, ' ').trim();
 };
 
+// A helper function to extract the color and background color from
+// css class the chrome-target-text.
+const getColors =
+    () => {
+      const style = document.getElementsByTagName('style')[0];
+      if (!style) return null;
+
+      const chromeTargetTextRules =
+          style.innerHTML.match(/.chrome-target-text\s*{\s*((.|\n)*?)\s*}/g);
+      if (!chromeTargetTextRules) return null;
+
+      const backgroundColor =
+          chromeTargetTextRules[0].match(/background-color\s*:\s*(.*?)\s*;/);
+      const color = chromeTargetTextRules[0].match(/[^-]color\s*:\s*(.*?)\s*;/);
+      const chromeTargetTextStyle = {
+        backgroundColor: backgroundColor ? backgroundColor[1] : null,
+        color: color ? color[1] : null
+      };
+      return chromeTargetTextStyle;
+    }
+
 describe('TextFragmentUtils', function() {
   it('gets directives from a hash', function() {
     const directives = utils.getFragmentDirectives('#foo:~:text=bar&text=baz');
@@ -463,35 +484,26 @@ describe('TextFragmentUtils', function() {
     document.body.innerHTML = __html__['target-text-test.html'];
 
     // complete ::target-text
-    let targetTextStyle = utils.getTargetTextStyle();
+    expect(utils.applyTargetTextStyle()).toBeTrue();
+    let targetTextStyle = getColors();
     expect(targetTextStyle.backgroundColor).toEqual('green');
     expect(targetTextStyle.color).toEqual('grey !important');
 
-    // wrong background color
+    // ::target-text scoped to an element
     document.getElementsByTagName('style')[0].innerHTML = `
-      ::target-text {
-        color: #FFC0CB;
-        background-color: wrong;
-      }
+    div::target-text {
+      background-color: rgb(230, 230, 250);
+    }
     `;
-    targetTextStyle = utils.getTargetTextStyle();
-    expect(targetTextStyle.color).toEqual('#FFC0CB');
-    expect(targetTextStyle.backgroundColor).toBeUndefined;
-
-    // no color
-    document.getElementsByTagName('style')[0].innerHTML = `
-      ::target-text {
-        background-color: rgb(230, 230, 250);
-      }
-    `;
-    targetTextStyle = utils.getTargetTextStyle();
+    expect(utils.applyTargetTextStyle()).toBeTrue();
+    targetTextStyle = getColors();
     expect(targetTextStyle.backgroundColor).toEqual('rgb(230, 230, 250)');
     expect(targetTextStyle.color).toBeUndefined;
 
     // no ::target-text
     document.body.innerHTML = __html__['marks_test.html'];
-    targetTextStyle = utils.getTargetTextStyle();
-    expect(targetTextStyle).toBeUndefined;
+    expect(utils.applyTargetTextStyle()).toBeFalse();
+    expect(getColors()).toBeUndefined;
   });
 
   it('should update <mark> style', function() {


### PR DESCRIPTION
# Changes

This PR updates getTargetTextStyle to replace all occurrences of the pseudo element `target-text` with a css class `chrome-target-text`. 