### PR TITLE
Add timeout to fragment generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "./dist/text-fragments.js",
   "browser": "./dist/text-fragments.js",


### PR DESCRIPTION
This patch adds a 400ms max run time to fragment generation, to
mitigate performance issues that can occur when runtime is excessive.

Bumps version to 3.0.0 since users who care about the |status| field
of GenerateFragmentResult need to handle a new enum value, but this
is not a widely breaking change.