### PR TITLE
Apply target-text style before setting text fragment default class

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -869,6 +869,7 @@ export const setDefaultTextFragmentsStyle = ({backgroundColor, color}) => {
         'beforeend', `<style type="text/css">${defaultStyle}</style>`);
   }
   else {
+    applyTargetTextStyle();
     const defaultStyleNode = document.createTextNode(defaultStyle);
     styles[0].insertBefore(defaultStyleNode, styles[0].firstChild);
   }

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -527,9 +527,9 @@ describe('TextFragmentUtils', function() {
       color: 'rgb(255, 165, 0)'
     };
     document.getElementsByTagName('style')[0].innerHTML =
-        '.text-fragments-polyfill-target-text { background-color: rgb(0, 250, 250)}' +
-        'b .text-fragments-polyfill-target-text { background-color: rgb(230, 230, 250)}' +
-        'p .text-fragments-polyfill-target-text { color: rgb(130, 130, 25)}';
+        '::target-text { background-color: rgb(0, 250, 250)}' +
+        'b::target-text { background-color: rgb(230, 230, 250)}' +
+        'p::target-text { color: rgb(130, 130, 25)}';
     utils.setDefaultTextFragmentsStyle(style);
     const range = document.createRange();
     range.setStart(document.getElementById('a').firstChild, 0);


### PR DESCRIPTION
# Changes

This PR applies the `::target-text` pseudo element style before appending the text fragment default style.