### PR TITLE
Update timeout API to use new status code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "./dist/text-fragments.js",
   "browser": "./dist/text-fragments.js",

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -626,14 +626,16 @@ describe('FragmentGenerationUtils', function() {
     selection.addRange(range);
 
     expect(function() {
-      generationUtils.generateFragment(selection, Date.now() - 1000);
+      generationUtils.forTesting.doGenerateFragment(
+          selection, Date.now() - 1000);
     }).toThrowMatching(function(thrown) {
       return thrown.isTimeout
     });
 
     generationUtils.setTimeout(2000);
     expect(function() {
-      generationUtils.generateFragment(selection, Date.now() - 1000);
+      generationUtils.forTesting.doGenerateFragment(
+          selection, Date.now() - 1000);
     }).not.toThrowMatching(function(thrown) {
       return thrown.isTimeout
     });


### PR DESCRIPTION
Rather than letting the timeout error escape the public API, we'll
catch it and return a new GenerateFragmentStatus code. This is in
response to feedback that having both status codes and errors led
to messier integrations.

This patch also includes a bit of housekeeping:
* Private methods are moved down below all public ones
* A few missing JSDocs are added