### PR TITLE
Fix race condition during initialization

### DIFF
--- a/src/text-fragments.js
+++ b/src/text-fragments.js
@@ -44,7 +44,11 @@ import * as utils from './text-fragment-utils.js';
     }
   };
   if (document.readyState !== 'complete') {
-    window.addEventListener('DOMContentLoaded', init);
+    document.addEventListener('readystatechange', event => {
+      if (event.target.readyState === 'complete') {
+        init();
+      }
+    });
   } else {
     init();
   }


### PR DESCRIPTION
The current init logic first checks whether `document.readyState === 'complete'` before calling `init()`, otherwise it starts listening for the `DOMContentLoaded` event and sets `init()` as the event callback.

According to the [DOMContentLoaded](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event) documentation, it can fire while `document.readyState` is still `'interactive'`. So, the current logic has a race condition where if the `DOMContentLoaded` event has already fired before we can start listening to it, and the `document.readyState` isn't `'complete'` yet, then `init()` will never be called. This was preventing the polyfill from working for the demo page (and other simple pages on the web like [www.example.com](www.example.com)) in some cases, such as in the FireFox browser.

The fix is to listen to the `readystatechange` event instead, because if `document.readyState` isn't `'complete'` yet, then we are guaranteed that the final `readystatechange` event hasn't fired yet, so it's safe to wait for it.

Fixes #60