### PR TITLE
searchSpace: add return if trimmed search space is empty

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -278,6 +278,8 @@ const getSearchSpaceForStart = (range) => {
       const trimmed = trimBoundary(candidate.toString());
       if (trimmed.length > 0) {
         return trimmed;
+      } else {
+        return undefined;
       }
     }
     node = forwardTraverse(walker, map);

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -297,7 +297,7 @@ describe('FragmentGenerationUtils', function() {
         .toEqual('f...oo');
   })
 
-  fit('can find the search space for range-based fragments', function() {
+  it('can find the search space for range-based fragments', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     const range = document.createRange();
 

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -297,7 +297,7 @@ describe('FragmentGenerationUtils', function() {
         .toEqual('f...oo');
   })
 
-  it('can find the search space for range-based fragments', function() {
+  fit('can find the search space for range-based fragments', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     const range = document.createRange();
 
@@ -358,6 +358,13 @@ describe('FragmentGenerationUtils', function() {
     expect(fragmentUtils.forTesting.normalizeString(
                generationUtils.forTesting.getSearchSpaceForEnd(range)))
         .toEqual('div with lots of different stuff');
+
+    // End boundary is a series of non-word characters at the end of a block
+    document.body.innerHTML = __html__['non-word-boundaries.html'];
+    range.setStart(document.getElementById('em').firstChild, 4);
+    range.setEnd(document.body, 3);
+    expect(generationUtils.forTesting.getSearchSpaceForStart(range))
+        .toEqual(undefined);
   });
 
   it('can generate progressively larger fragments across blocks', function() {

--- a/test/non-word-boundaries.html
+++ b/test/non-word-boundaries.html
@@ -1,0 +1,3 @@
+<body>
+  <p><em id="em">test...</em></p>
+</body>


### PR DESCRIPTION
The getSearchSpaceForStart function currently does not return if it hits a block boundary but the trimmed search space is an empty string. This causes the traversal to continue, which doesn't make sense because the search space cannot cross block boundaries.

The fix is to return undefined, because it has been determined that there are no more words after the selection within the block, meaning there is no additional search space.

Fixes #63