### PR TITLE
Fix overrideMap generation logic

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -996,9 +996,9 @@ const createForwardOverrideMap = (walker) => {
     if (walker.currentNode !== node) overrideMap.set(walker.currentNode, node);
 
     // Also set a mapping from the ancestor to the child's next node, which is
-    // |TreeWalker.nextNode()| unless it had already been overriden in the map.
-    // This might get overwritten later if another ancestor needs to get
-    // inserted in the ordering too.
+    // |TreeWalker.nextNode()| unless it had already been overridden in the map.
+    // This override might change in a later iteration if another ancestor needs
+    // to get inserted in the ordering too.
     overrideMap.set(node, previousOverride || walker.nextNode());
 
     // Reset the walker to where it was before we traversed downwards.

--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -989,13 +989,17 @@ const createForwardOverrideMap = (walker) => {
       }
     }
 
-    // Set the mapping from the found child to its ancestor.
+    // Remember the current override, if any, for the found child.
+    const previousOverride = overrideMap.get(walker.currentNode);
+
+    // Set a mapping from the found child to its ancestor.
     if (walker.currentNode !== node) overrideMap.set(walker.currentNode, node);
 
-    // Next, set a mapping from the ancestor to the node it displaced in the
-    // ordering. This might get overwritten later if another ancestor needs to
-    // get inserted in the ordering too.
-    overrideMap.set(node, walker.nextNode());
+    // Also set a mapping from the ancestor to the child's next node, which is
+    // |TreeWalker.nextNode()| unless it had already been overriden in the map.
+    // This might get overwritten later if another ancestor needs to get
+    // inserted in the ordering too.
+    overrideMap.set(node, previousOverride || walker.nextNode());
 
     // Reset the walker to where it was before we traversed downwards.
     walker.currentNode = node;

--- a/test/non-word-boundaries.html
+++ b/test/non-word-boundaries.html
@@ -1,3 +1,3 @@
 <body>
-  <p><em id="em">test...</em></p>
+  <p id="p"><em id="em">test...</em></p>
 </body>


### PR DESCRIPTION
The current |createForwardOverrideMap| function can create cycles, which could potentially lead to infinite loops when traversing the DOM under certain circumstances.

The problem is that when creating an override, |walker.nextNode()| is used to determine which node to traverse next. This is wrong if the node to be traversed next had already been overridden. The fix is to simply check the override map to see if the current node already had an override for its next node, and if so, use that as the ancestor's override.

Fixes #61 