### PR TITLE
Undo the early return in getSearchSpaceForStart

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -278,8 +278,6 @@ const getSearchSpaceForStart = (range) => {
       const trimmed = trimBoundary(candidate.toString());
       if (trimmed.length > 0) {
         return trimmed;
-      } else {
-        return undefined;
       }
     }
     node = forwardTraverse(walker, map);


### PR DESCRIPTION
The recent fix of returning early when determining the search space has broken a range-based generation unit test. It is safer to undo the change, especially since the cycle generation in the override map has been fixed, which is sufficient to address the generation failures and to pass the corresponding unit tests.

Fixes #67