### PR TITLE
Clean up trimBoundary util

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -694,24 +694,6 @@ const isUniquelyIdentifying = (fragment) => {
 };
 
 /**
- * Analogous to the standard String trim method, but removes any boundary chars,
- * not just whitespace.
- * @param {String} string - the string to trim
- * @return {String} - the trimmed string
- */
-const trimBoundary = (string) => {
-  const startIndex = string.search(fragments.internal.NON_BOUNDARY_CHARS);
-
-  let endIndex =
-      reverseString(string).search(fragments.internal.NON_BOUNDARY_CHARS);
-  if (endIndex !== -1) endIndex = string.length - endIndex;
-
-  if (startIndex === -1 || endIndex === -1 || startIndex >= endIndex) return '';
-
-  return string.substring(startIndex, endIndex);
-};
-
-/**
  * Reverses a string. Compound unicode characters are preserved.
  * @param {String} string - the string to reverse
  * @return {String} - sdrawkcab |gnirts|
@@ -1148,7 +1130,6 @@ export const forTesting = {
   getSearchSpaceForEnd: getSearchSpaceForEnd,
   getSearchSpaceForStart: getSearchSpaceForStart,
   recordStartTime: recordStartTime,
-  trimBoundary: trimBoundary,
 };
 
 // Allow importing module from closure-compiler projects that haven't migrated

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -311,17 +311,6 @@ describe('FragmentGenerationUtils', function() {
     ]);
   });
 
-  it('can trim leading/trailing boundary characters from a string', function() {
-    expect(generationUtils.forTesting.trimBoundary('foo')).toEqual('foo');
-    expect(generationUtils.forTesting.trimBoundary(' foo')).toEqual('foo');
-    expect(generationUtils.forTesting.trimBoundary('foo ')).toEqual('foo');
-    expect(generationUtils.forTesting.trimBoundary('  foo  ')).toEqual('foo');
-    expect(generationUtils.forTesting.trimBoundary('\n\'[]!foö...'))
-        .toEqual('foö');
-    expect(generationUtils.forTesting.trimBoundary('...f...oo...'))
-        .toEqual('f...oo');
-  })
-
   it('can find the search space for range-based fragments', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     const range = document.createRange();


### PR DESCRIPTION
With #73, the trimBoundary() function isn't needed anymore, so this CL removes it. If we ever need it back, we can add it from history.