### PR TITLE
Fix prefix/suffix issue

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -200,7 +200,7 @@ const doGenerateFragment = (selection, startTime) => {
   const prefixSearchSpace = getSearchSpaceForEnd(prefixRange);
   const suffixSearchSpace = getSearchSpaceForStart(suffixRange);
 
-  if (prefixSearchSpace && suffixSearchSpace) {
+  if (prefixSearchSpace || suffixSearchSpace) {
     factory.setPrefixAndSuffixSearchSpace(prefixSearchSpace, suffixSearchSpace);
   }
 
@@ -584,12 +584,16 @@ const FragmentFactory = class {
    *     assignment
    */
   setPrefixAndSuffixSearchSpace(prefixSearchSpace, suffixSearchSpace) {
-    this.prefixSearchSpace = prefixSearchSpace;
-    this.backwardsPrefixSearchSpace = reverseString(prefixSearchSpace);
-    this.prefixOffset = prefixSearchSpace.length;
+    if (prefixSearchSpace) {
+      this.prefixSearchSpace = prefixSearchSpace;
+      this.backwardsPrefixSearchSpace = reverseString(prefixSearchSpace);
+      this.prefixOffset = prefixSearchSpace.length;
+    }
 
-    this.suffixSearchSpace = suffixSearchSpace;
-    this.suffixOffset = 0;
+    if (suffixSearchSpace) {
+      this.suffixSearchSpace = suffixSearchSpace;
+      this.suffixOffset = 0;
+    }
 
     return this;
   }

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -101,6 +101,44 @@ describe('FragmentGenerationUtils', function() {
     expect(result.fragment.textStart).toEqual('elle a brise');
   });
 
+  it('handles a prefix without a suffix', function() {
+    document.body.innerHTML = __html__['prefix-suffix-at-edges.html'];
+
+    const target = document.createRange();
+    const selection = window.getSelection();
+    const startnode = document.body.firstChild.firstChild;
+    target.setStart(startnode, 21);
+    target.setEnd(startnode, 27);
+    selection.removeAllRanges();
+    selection.addRange(target);
+
+    const result = generationUtils.generateFragment(selection);
+    expect(result.status)
+        .toEqual(generationUtils.GenerateFragmentStatus.SUCCESS);
+    expect(result.fragment.textStart).toEqual('target');
+    expect(result.fragment.prefix).toEqual('prefix');
+    expect(result.fragment.suffix).toBeUndefined();
+  });
+
+  it('handles a suffix without a prefix', function() {
+    document.body.innerHTML = __html__['prefix-suffix-at-edges.html'];
+
+    const target = document.createRange();
+    const selection = window.getSelection();
+    const startnode = document.body.firstChild.firstChild;
+    target.setStart(startnode, 0);
+    target.setEnd(startnode, 6);
+    selection.removeAllRanges();
+    selection.addRange(target);
+
+    const result = generationUtils.generateFragment(selection);
+    expect(result.status)
+        .toEqual(generationUtils.GenerateFragmentStatus.SUCCESS);
+    expect(result.fragment.textStart).toEqual('target');
+    expect(result.fragment.suffix).toEqual('suffix');
+    expect(result.fragment.prefix).toBeUndefined();
+  });
+
   it('can detect if a range contains a block boundary', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     const range = document.createRange();

--- a/test/prefix-suffix-at-edges.html
+++ b/test/prefix-suffix-at-edges.html
@@ -1,0 +1,1 @@
+<p>target suffix prefix target</p>


### PR DESCRIPTION
Previously we would not attempt to add a prefix/suffix unless both
prefix and suffix had a nonempty search space, which means that,
for example, we couldn't generate a link to either instance of
"target" in the paragraph:

  target suffix prefix target

This patch attempts to add a prefix/suffix if either one has a
nonempty search space.