### PR TITLE
Use Intl.Segmenter in word bound check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "./dist/text-fragments.js",
   "browser": "./dist/text-fragments.js",

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -736,7 +736,7 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
  * If an Intl.Segmenter is provided for locale-specific segmenting, it will be
  * used for this check. This is the most desirable option, but not supported in
  * all browsers.
- * 
+ *
  * If one is not provided, a heuristic will be applied,
  * returning true iff:
  *  - startPos == 0 OR char before start is a boundary char, AND
@@ -744,7 +744,7 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
  * Where boundary chars are whitespace/punctuation defined in the const above.
  * This causes the known issue that some languages, notably Japanese, only match
  * at the level of roughly a full clause or sentence, rather than a word.
- * 
+ *
  * @param {String} text - the text to search
  * @param {Number} startPos - the index of the start of the substring
  * @param {Number} length - the length of the substring
@@ -771,15 +771,17 @@ const isWordBounded = (text, startPos, length, segmenter) => {
     // it's punctuation, etc., so that counts for word bounding.
     if (startSegment.isWordLike && startSegment.index != startPos) return false;
 
+    // |endPos| points to the first character outside the target substring.
     const endPos = startPos + length;
     const endSegment = segments.containing(endPos);
 
     // If there's no end segment found, it's because we're at the end of the
     // text, which is a valid boundary. (Because of the preconditions we
     // checked above, we know we aren't out of range.)
-    // If there is an end segment found, it must either be non-word-like (i.e.,
-    // punctuation/whitespace) or the endPos must indicate the first character
-    // of a new word.
+    // If there's an end segment found but it's non-word-like, that's also OK,
+    // since punctuation and whitespace are acceptable boundaries.
+    // Lastly, if there's an end segment and it is word-like, then |endPos|
+    // needs to point to the start of that new word, or |endSegment.index|.
     if (endSegment && endSegment.isWordLike && endSegment.index != endPos)
       return false;
   } else {

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -293,7 +293,7 @@ describe('TextFragmentUtils', function() {
         );
   });
 
-  it('can advance a range start past boundary chars', function() {
+  it('can advance a range start past whitespace chars', function() {
     document.body.innerHTML = __html__['marks_test.html'];
     const range = document.createRange();
     const elt = document.getElementById('a').firstChild;
@@ -320,7 +320,7 @@ describe('TextFragmentUtils', function() {
             'this is a really ',
         );
 
-    // Offset 10 is after the last non-boundary char in this node. Advancing
+    // Offset 10 is after the last non-whitespace char in this node. Advancing
     // will move past this node's trailing whitespace, into the next text node,
     // and past that node's leading whitespace.
     range.setStart(elt, 10);
@@ -404,7 +404,7 @@ describe('TextFragmentUtils', function() {
         .toBeUndefined();
   });
 
-  it('can detect if a substring is word-bounded', function() {
+  it('can detect if a substring is word-bounded without a segmenter', function() {
     const trueCases = [
       {data: 'test', substring: 'test'},
       {data: 'multiword test string', substring: 'test'},
@@ -414,7 +414,8 @@ describe('TextFragmentUtils', function() {
       {data: 'text foo bar', substring: 'foo '},
       {data: 'text  foo bar', substring: '  foo'},
       {data: 'text foo bar', substring: ' foo '},
-      // Japanese has no spaces, so only punctuation works as a boundary.
+      // Japanese has no spaces, so only punctuation works as a boundary without
+      // Intl.Segmenter.
       {data: 'はい。いいえ。', substring: 'いいえ'},
       {data: '『パープル・レイン』', substring: 'パープル'},
     ];
@@ -425,9 +426,8 @@ describe('TextFragmentUtils', function() {
       {data: 'untested', substring: 'test'},
       {data: '  hello ', substring: '  '},
       {data: ' hello  ', substring: '  '},
-      // アルバム is an actual word. With proper Japanese word segmenting we
-      // could move this to the true cases, but for now we expect it to be
-      // rejected.
+      // アルバム is an actual word in Japanese, but without Intl.Segmenter we
+      // can't detect that, so we expect false here.
       {
         data:
             'プリンス・アンド・ザ・レヴォリューションによる1984年のアルバム。',
@@ -464,6 +464,79 @@ describe('TextFragmentUtils', function() {
                   '>',
               )
           .toEqual(false);
+    }
+  });
+
+  it('can detect if a substring is word-bounded with a segmenter', function() {
+    if (!Intl.Segmenter) {
+      pending('This configuration does not yet support Intl.Segmenter.');
+      return;
+    }
+
+    const testCases = [
+      {
+        lang: 'en',
+        matches: [
+          {data: 'test', substring: 'test'},
+          {data: 'multiword test string', substring: 'test'},
+          {data: 'the quick, brown dog', substring: 'the quick'},
+          {data: 'a "quotation" works', substring: 'quotation'},
+          {data: 'other\nspacing\t', substring: 'spacing'},
+          {data: 'text foo bar', substring: 'foo '},
+          {data: 'text  foo bar', substring: '  foo'},
+          {data: 'text foo bar', substring: ' foo '},
+          {data: 'there are 4 lights', substring: '4'},
+        ],
+        nonmatches: [
+          {data: 'testing', substring: 'test'},
+          {data: 'attest', substring: 'test'},
+          {data: 'untested', substring: 'test'},
+        ]
+      },
+      {
+        lang: 'jp',
+        matches: [
+          {data: 'はい。いいえ。', substring: 'いいえ'},
+          {data: '『パープル・レイン』', substring: 'パープル'},
+          {
+            data:
+                'プリンス・アンド・ザ・レヴォリューションによる1984年のアルバム。',
+            substring: 'アルバム',
+          },
+          {data: 'ウィキペディアへようこそ', substring: 'ようこそ'},
+        ],
+        nonmatches: [
+          {data: 'ウィキペディアへようこそ', substring: 'ようこ'},
+        ]
+      }
+    ];
+    for (const testCase of testCases) {
+      const segmenter =
+          new Intl.Segmenter(testCase.lang, {granularity: 'word'});
+      for (const input of testCase.matches) {
+        const index = input.data.search(input.substring);
+        expect(
+            utils.forTesting.isWordBounded(
+                input.data, index, input.substring.length, segmenter),
+            )
+            .withContext(
+                'Is <' + input.substring + '> word-bounded in <' + input.data +
+                    '>',
+                )
+            .toEqual(true);
+      }
+      for (const input of testCase.nonmatches) {
+        const index = input.data.search(input.substring);
+        expect(
+            utils.forTesting.isWordBounded(
+                input.data, index, input.substring.length, segmenter),
+            )
+            .withContext(
+                'Is <' + input.substring + '> word-bounded in <' + input.data +
+                    '>',
+                )
+            .toEqual(false);
+      }
     }
   });
 

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -503,10 +503,21 @@ describe('TextFragmentUtils', function() {
                 'プリンス・アンド・ザ・レヴォリューションによる1984年のアルバム。',
             substring: 'アルバム',
           },
+          {
+            data: '秋葉原（あきはばら）は、東京都千代田区の秋葉原駅周辺',
+            substring: '東京都',  // 東京都 is a full word (Tokyo)
+          },
           {data: 'ウィキペディアへようこそ', substring: 'ようこそ'},
         ],
         nonmatches: [
-          {data: 'ウィキペディアへようこそ', substring: 'ようこ'},
+          {
+            data: 'ウィキペディアへようこそ',
+            substring: 'ようこ'
+          },  // ようこそ is the full word
+          {
+            data: '秋葉原（あきはばら）は、東京都千代田区の秋葉原駅周辺',
+            substring: '東京都千',  // 東京都 and 千代田区 are the full words
+          },
         ]
       }
     ];


### PR DESCRIPTION
This patch allows the optional use of Intl.Segmenter for improved word bound checks. Note that this does not, by default, affect the end-to-end fragment finding algorithm. A future patch will actually *supply* a Segmenter (where available) so that this logic will be applied.