### PR TITLE
Use Intl.Segmenter for highlighting, where available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.6.0",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "./dist/text-fragments.js",
   "browser": "./dist/text-fragments.js",

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -369,12 +369,14 @@ describe('TextFragmentUtils', function() {
     const docRange = document.createRange();
     docRange.selectNodeContents(rootNode);
 
+    let segmenter = null;
+    if (Intl.Segmenter) {
+      segmenter = new Intl.Segmenter('en', {granularity: 'word'});
+    }
+
     for (const input of simpleTestCases) {
       const range = utils.forTesting.findRangeFromNodeList(
-          input,
-          docRange,
-          allTextNodes,
-      );
+          input, docRange, allTextNodes, segmenter);
       expect(range)
           .withContext('No range found for <' + input + '>')
           .not.toBeUndefined();
@@ -385,20 +387,14 @@ describe('TextFragmentUtils', function() {
     // the word 'has'. We verify this by checking that the range's common
     // ancestor is the <b> tag, which in the HTML doc contains the word 'a'.
     const aRange = utils.forTesting.findRangeFromNodeList(
-        'a',
-        docRange,
-        allTextNodes,
-    );
+        'a', docRange, allTextNodes, segmenter);
     expect(aRange).withContext('No range found for <a>').not.toBeUndefined();
     expect(aRange.commonAncestorContainer.parentElement.nodeName).toEqual('B');
 
     // We expect no match to be found for a partial-word substring ("tüf" should
     // not match "stüff" in the document).
     const nullRange = utils.forTesting.findRangeFromNodeList(
-        'tüf',
-        docRange,
-        allTextNodes,
-    );
+        'tüf', docRange, allTextNodes, segmenter);
     expect(nullRange)
         .withContext('Unexpectedly found match for <tüf>')
         .toBeUndefined();


### PR DESCRIPTION
This change supplies an Intl.Segmenter instance to the word bound
checking utils, where supported. This dramatically improves
the chances of a successful highlight in Japanese, Chinese, and
other non-space-separated languages.

This is not a breaking change. The old logic still exists and
is used in browsers which do not yet support Intl.Segmenter, and
the modified util functions treat the segmenter as an optional arg.
However, because this significantly affects real-world behavior, I
am treating this as a major version upgrade (4.0).