### PR TITLE
Add two util functions

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -598,14 +598,8 @@ function* getElementsIn(root, filter) {
  */
 const findTextInRange = (query, range) => {
   const textNodeLists = getAllTextNodes(range.commonAncestorContainer, range);
-  let segmenter = null;
-  if (Intl.Segmenter) {
-    let lang = document.documentElement.lang;
-    if (!lang) {
-      lang = navigator.languages;
-    }
-    segmenter = new Intl.Segmenter(lang, {granularity: 'word'});
-  }
+  const segmenter = makeNewSegmenter();
+
   for (const list of textNodeLists) {
     const found = findRangeFromNodeList(query, range, list, segmenter);
     if (found !== undefined) return found;
@@ -844,6 +838,17 @@ const normalizeString = (str) => {
       .toLowerCase();
 };
 
+const makeNewSegmenter = () => {
+  if (Intl.Segmenter) {
+    let lang = document.documentElement.lang;
+    if (!lang) {
+      lang = navigator.languages;
+    }
+    return new Intl.Segmenter(lang, {granularity: 'word'});
+  }
+  return undefined;
+};
+
 /**
  * Should not be referenced except in the /test directory.
  */
@@ -868,6 +873,7 @@ export const internal = {
   NON_BOUNDARY_CHARS: NON_BOUNDARY_CHARS,
   filterFunction: filterFunction,
   normalizeString: normalizeString,
+  makeNewSegmenter: makeNewSegmenter,
 }
 
 // Allow importing module from closure-compiler projects that haven't migrated

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -799,4 +799,36 @@ describe('FragmentGenerationUtils', function() {
     expect(generationUtils.isValidRangeForFragmentGeneration(range))
         .toBeFalse();
   });
+
+  it('can find text nodes in the same block as another node', function() {
+    const extractor =
+        (x) => {
+          return x.textContent.trim();
+        }
+
+               document.body.innerHTML = __html__['text-node-extraction.html'];
+    let node = document.getElementById('outer').childNodes[0];
+    let result = generationUtils.forTesting.getTextNodesInSameBlock(node);
+    expect(extractor(node)).toBe('0');
+    expect(result.preNodes.map(extractor)).toEqual([]);
+    expect(result.postNodes.map(extractor)).toEqual([]);
+
+    node = document.getElementById('inner').childNodes[0];
+    result = generationUtils.forTesting.getTextNodesInSameBlock(node);
+    expect(extractor(node)).toBe('1');
+    expect(result.preNodes.map(extractor)).toEqual([]);
+    expect(result.postNodes.map(extractor)).toEqual(['2', '3', '4', '5']);
+
+    node = document.getElementById('mid').childNodes[0];
+    result = generationUtils.forTesting.getTextNodesInSameBlock(node);
+    expect(extractor(node)).toBe('4');
+    expect(result.preNodes.map(extractor)).toEqual(['1', '2', '3']);
+    expect(result.postNodes.map(extractor)).toEqual(['5']);
+
+    node = document.getElementById('outer').childNodes[2];
+    result = generationUtils.forTesting.getTextNodesInSameBlock(node);
+    expect(extractor(node)).toBe('8');
+    expect(result.preNodes.map(extractor)).toEqual([]);
+    expect(result.postNodes.map(extractor)).toEqual([]);
+  });
 });

--- a/test/text-node-extraction.html
+++ b/test/text-node-extraction.html
@@ -1,0 +1,13 @@
+<div id="outer">
+  0
+  <div id="inner">
+    1
+    <i>2</i>
+    3
+    <span id="mid">4</span>
+    5
+    <div>6</div>
+    7
+  </div>
+  8
+</div>


### PR DESCRIPTION
Two new util functions are added to prepare for upcoming
Intl.Segmenter support in the fragment generation process. One
simply extracts the existing code for creating a Segmenter for
reuse. The other extracts all the text nodes at the same block
level as a given node, which will be needed in a forthcoming
patch.