### PR TITLE
Update range expansion algorithm to use Intl.Segmenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "./dist/text-fragments.js",
   "browser": "./dist/text-fragments.js",

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -241,6 +241,34 @@ describe('FragmentGenerationUtils', function() {
     expect(range.toString()).toEqual('block');
   });
 
+  it('can expand a range start to a word bound across nodes in Japanese',
+     function() {
+       if (!Intl.Segmenter) {
+         pending('This configuration does not yet support Intl.Segmenter.');
+         return;
+       }
+
+       document.body.innerHTML = __html__['jp-word-boundary.html'];
+       const range = document.createRange();
+       // The last text node contains a partial word and needs to include a char
+       // from the preceding <i> tag to make a full word.
+       const wordSuffix = document.getElementById('root').lastChild;
+       range.selectNodeContents(wordSuffix);
+       expect(range.toString()).toEqual('リーズ');
+
+       generationUtils.forTesting.expandRangeStartToWordBound(range);
+       expect(range.toString()).toEqual('シリーズ');
+
+       // This node contains the end of one word and the start of another, but
+       // in context is not a full word itself.
+       const innerText = document.getElementById('i').firstChild;
+       range.selectNodeContents(innerText);
+       expect(range.toString()).toEqual('ックシ');
+
+       generationUtils.forTesting.expandRangeStartToWordBound(range);
+       expect(range.toString()).toEqual('ソニックシ');
+     });
+
   it('can expand a range end to a word bound within a node', function() {
     document.body.innerHTML = __html__['word_bounds_test.html'];
     const range = document.createRange();

--- a/test/jp-word-boundary.html
+++ b/test/jp-word-boundary.html
@@ -1,0 +1,1 @@
+<div id="root">ソニ<i id="i">ックシ</i>リーズ</div>


### PR DESCRIPTION
This change updates the expandRangeStartToWordBound method to use
Intl.Segmenter, where supported. A follow-up patch will modify the
corresponding range end method, using similar logic.