### PR TITLE
Use Intl.Segmenter for expanding range ends to word bounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.5.0",

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -239,6 +239,10 @@ describe('FragmentGenerationUtils', function() {
 
     generationUtils.forTesting.expandRangeStartToWordBound(range);
     expect(range.toString()).toEqual('block');
+
+    // Repeat the process and expect it to be a no-op.
+    generationUtils.forTesting.expandRangeStartToWordBound(range);
+    expect(range.toString()).toEqual('block');
   });
 
   it('can expand a range start to a word bound across nodes in Japanese',
@@ -278,6 +282,10 @@ describe('FragmentGenerationUtils', function() {
     range.setEnd(textNodeInBlock, 3);
     expect(range.toString()).toEqual('Ins');
 
+    generationUtils.forTesting.expandRangeEndToWordBound(range);
+    expect(range.toString()).toEqual('Inside');
+
+    // Repeat the process and expect it to be a no-op.
     generationUtils.forTesting.expandRangeEndToWordBound(range);
     expect(range.toString()).toEqual('Inside');
   });


### PR DESCRIPTION
This patch mirrors the last, which implemented Intl.Segmenter support for expanding range starts.

Specifically, it:
* Extracts most of the logic of `expandRangeStartToWordBound` to a new helper method, `expandToNearestWordBoundaryPointUsingSegments`.
* Adds logic to `getTextNodesInSameBlock` to also return any text subnodes of the given node, if it is not already a text node. This is mainly needed because DOM traversal works differently in reverse (if we traverse _forward_ from `node` we will traverse all of its children; if we traverse _backward_ from `node` we do not).

The diff will also show some changes to `backwardTraverse` and the existing body of `expandRangeStartToWordBound`, but these are just auto-formatting.