### PR TITLE
Add context on first iteration for short range-based matches

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -519,7 +519,9 @@ const FragmentFactory = class {
     }
 
     let canExpandContext = false;
-    if (!canExpandRange ||  // TODO: check if range match is < 20 chars
+    if (!canExpandRange ||
+        this.startOffset + this.backwardsEndOffset() <
+            MIN_LENGTH_WITHOUT_CONTEXT ||
         this.numIterations >= ITERATIONS_BEFORE_ADDING_CONTEXT) {
       // Check if there's any unused search space left.
       if ((this.backwardsPrefixOffset() != null &&


### PR DESCRIPTION
This is a follow-up completing a TODO in the last patch. Context
(prefix/suffix) will now be added to generated fragments on the
first iteration when the text for a range-based match is short.
This helps reduce the number of short phrases we search for in
the document, improving our odds of not timing out.