### PR TITLE
Fix extraneous characters when expanding JP ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "text-fragments-polyfill",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-fragments-polyfill",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "This is a polyfill for the [Text Fragments](https://wicg.github.io/scroll-to-text-fragment/) feature for browsers that don't support it natively.",
   "main": "./dist/text-fragments.js",
   "browser": "./dist/text-fragments.js",

--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1279,22 +1279,11 @@ const expandToNearestWordBoundaryPointUsingSegments =
         return;
       }
 
-      // Edge case: if we are at the first/last character of the segment, we
-      // need to check if the one before/after it is whitespace.
-      if (offsetInText === foundSegment.index) {
-        const prevSegment = segments.containing(offsetInText - 1);
-        // |prevSegment| will be undefined if |offsetInText| is 0
-        if (prevSegment && !prevSegment.isWordLike) {
-          return;
-        }
-      }
-      if (offsetInText === foundSegment.index + foundSegment.segment.length) {
-        const nextSegment = segments.containing(offsetInText + 1);
-        // |nextSegment| will be undefined if |offsetInText| is past the end of
-        // |text|
-        if (nextSegment && !nextSegment.isWordLike) {
-          return;
-        }
+      // Another easy case: if we are at the first/last character of the
+      // segment, then we're done.
+      if (offsetInText === foundSegment.index ||
+          offsetInText === foundSegment.index + foundSegment.segment.length) {
+        return;
       }
 
       // We're inside a word. Based on |isRangeEnd|, the target offset will

--- a/test/jp-sentence.html
+++ b/test/jp-sentence.html
@@ -1,0 +1,4 @@
+<!-- This is just a sentence from the constitution of Japan, for testing segmenting/generation -->
+<div id="root">
+  日本國民は、國家の名譽にかけ、全󠄁力をあげてこの崇高な理想と目的を達󠄁成󠄁することを誓ふ。
+</div>


### PR DESCRIPTION
Currently when we call expandToNearestWordBoundaryPointUsingSegments
on text in Japanese (or any non-space-separated language) we often
include too much text. This is because, if the range already ends on
a word boundary, we jump to the end of the segment where it ends
(i.e., we add another word).

The fix for this is simple; we just early-return whenever the range
points to the beginning/end of a segment, regardless of whether or
not that segment is whitespace.