### PR TITLE
Adding test case for known issue with invisible text

### DIFF
--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -483,6 +483,26 @@ describe('FragmentGenerationUtils', function() {
         .toEqual('...');
   });
 
+  it('excludes invisible text nodes when getting search space', function() {
+    pending('This is a known issue. This test should be reenabled when fixed.');
+    document.body.innerHTML = __html__['invisible-text-node.html'];
+
+    const range = document.createRange();
+    range.setStartBefore(document.getElementById('prefix'));
+    range.setEndAfter(document.getElementById('prefix'));
+
+    const prefixSearchSpace =
+        generationUtils.forTesting.getSearchSpaceForEnd(range);
+    expect(prefixSearchSpace).toEqual('visible1');
+
+    range.setStartBefore(document.getElementById('suffix'));
+    range.setEndAfter(document.getElementById('suffix'));
+
+    const suffixSearchSpace =
+        generationUtils.forTesting.getSearchSpaceForEnd(range);
+    expect(suffixSearchSpace).toEqual('visible2');
+  });
+
   it('can generate progressively larger fragments across blocks', function() {
     document.body.innerHTML = __html__['range-fragment-test.html'];
     const range = document.createRange();

--- a/test/invisible-text-node.html
+++ b/test/invisible-text-node.html
@@ -1,0 +1,9 @@
+<div id="prefix">
+  visible1
+  <span style="display: none">invisible1</span>
+</div>
+<span id="target">target text</span>
+<div id="suffix">
+  <span style="display: none">invisible2</span>
+  visible2
+</div>


### PR DESCRIPTION
When generating the search space for the prefix and suffix, we
attempt to exclude invisible nodes. However, invisible nodes
*between* visible nodes are incorrectly included in the search
space.

This patch adds a test case which is pending (disabled), to
facilitate development of a fix. A future patch will fix the bug
and enable the test.

This issue was first documented at crbug.com/1276014