### PR TITLE
Refactor filterFunction

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1257,7 +1257,7 @@ const makeWalkerForNode = (node, endNode) => {
 
   const walker = document.createTreeWalker(
       blockAncestor, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, (node) => {
-        return fragments.internal.filterFunction(node);
+        return fragments.internal.visibleNodesInRangeFilterFunction(node);
       });
 
   walker.currentNode = node;
@@ -1486,7 +1486,7 @@ const getTextNodesInSameBlock = (node) => {
   } else {
     const walker = document.createTreeWalker(
         node, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, (node) => {
-          return fragments.internal.filterFunction(node);
+          return fragments.internal.visibleNodesInRangeFilterFunction(node);
         });
     walker.currentNode = node;
     let child = walker.nextNode();

--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1257,7 +1257,7 @@ const makeWalkerForNode = (node, endNode) => {
 
   const walker = document.createTreeWalker(
       blockAncestor, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, (node) => {
-        return fragments.internal.visibleNodesInRangeFilterFunction(node);
+        return fragments.internal.acceptNodeIfVisibleInRange(node);
       });
 
   walker.currentNode = node;
@@ -1486,7 +1486,7 @@ const getTextNodesInSameBlock = (node) => {
   } else {
     const walker = document.createTreeWalker(
         node, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, (node) => {
-          return fragments.internal.visibleNodesInRangeFilterFunction(node);
+          return fragments.internal.acceptNodeIfVisibleInRange(node);
         });
     walker.currentNode = node;
     let child = walker.nextNode();

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -361,7 +361,7 @@ const advanceRangeStartToNonWhitespace = (range) => {
       range.commonAncestorContainer,
       NodeFilter.SHOW_TEXT,
       (node) => {
-        return visibleNodesInRangeFilterFunction(node, range);
+        return acceptNodeIfVisibleInRange(node, range);
       },
   );
   let node = walker.nextNode();
@@ -514,7 +514,7 @@ const isNodeVisible =
  * @return {NodeFilter} - FILTER_ACCEPT or FILTER_REJECT, to be passed along to
  *     a TreeWalker.
  */
-const visibleNodesInRangeFilterFunction = (node, range) => {
+const acceptNodeIfVisibleInRange = (node, range) => {
   if (range != null && !range.intersectsNode(node))
     return NodeFilter.FILTER_REJECT;
 
@@ -538,7 +538,7 @@ const getAllTextNodes = (root, range) => {
       getElementsIn(
           root,
           (node) => {
-            return visibleNodesInRangeFilterFunction(node, range);
+            return acceptNodeIfVisibleInRange(node, range);
           }),
   );
 
@@ -977,7 +977,7 @@ export const internal = {
   BLOCK_ELEMENTS: BLOCK_ELEMENTS,
   BOUNDARY_CHARS: BOUNDARY_CHARS,
   NON_BOUNDARY_CHARS: NON_BOUNDARY_CHARS,
-  visibleNodesInRangeFilterFunction: visibleNodesInRangeFilterFunction,
+  acceptNodeIfVisibleInRange: acceptNodeIfVisibleInRange,
   normalizeString: normalizeString,
   makeNewSegmenter: makeNewSegmenter,
   forwardTraverse: forwardTraverse,


### PR DESCRIPTION
In this patch I'm renaming filterFunction to visibleNodesInRangeFilterFunction and moving the logic to calculate a node's visibility to a separate function. The reason for the refactoring is that we need a different filter function for text-fragment-utils.advanceRangeStartToNonWhitespace. The new filter function will reuse the visibility computation logic and will be added in a future PR.

This PR doesn't change any behaviour. 