### PR TITLE
Fix crash in expandToNearestWordBoundaryPointUsingSegments

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1378,6 +1378,14 @@ const expandToNearestWordBoundaryPointUsingSegments =
 
       const allNodes =
           [...nodes.preNodes, ...nodes.innerNodes, ...nodes.postNodes];
+
+      // Edge case: There's no text nodes in the block.
+      // In that case there's nothing to do because there is no word boundary
+      // to find.
+      if (allNodes.length == 0) {
+        return;
+      }
+
       const text = preNodeText.concat(innerNodeText, postNodeText);
 
       const segments = segmenter.segment(text);

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -1245,4 +1245,46 @@ describe('FragmentGenerationUtils', function() {
 
        expect(accumulator.textInBlock).toEqual(null);
      });
+
+  // Test expanding ranges to word bounds when there's no text nodes in the
+  // block.
+  it('Given range with no text nodes in the same block as startContainer\n' +
+         'When expandRangeStartToWordBound is called\n' +
+         'Then range is returned without changes',
+     function() {
+       document.body.innerHTML = __html__['no-text-nodes-in-range.html'];
+
+       const startNode = document.getElementById('1');
+       const endNode = document.getElementById('2');
+
+       const range = document.createRange();
+       range.setStartBefore(startNode);
+       range.setEndAfter(endNode);
+
+       const expectedRange = range.cloneRange();
+
+       generationUtils.forTesting.expandRangeStartToWordBound(range);
+
+       expect(range).toEqual(expectedRange);
+     });
+
+  it('Given range with no text nodes in the same block as endContainer\n' +
+         'When expandRangeEndToWordBound is called\n' +
+         'Then range is returned without changes',
+     function() {
+       document.body.innerHTML = __html__['no-text-nodes-in-range.html'];
+
+       const startNode = document.getElementById('1');
+       const endNode = document.getElementById('2');
+
+       const range = document.createRange();
+       range.setStartBefore(startNode);
+       range.setEndAfter(endNode);
+
+       const expectedRange = range.cloneRange();
+
+       generationUtils.forTesting.expandRangeEndToWordBound(range);
+
+       expect(range).toEqual(expectedRange);
+     });
 });

--- a/test/no-text-nodes-in-range.html
+++ b/test/no-text-nodes-in-range.html
@@ -1,0 +1,1 @@
+<div><img id="1" /><img id="2" /></div>


### PR DESCRIPTION
This patch covers an edge case of expandToNearestWordBoundaryPointUsingSegments when the start/end of the range can't reach any text nodes without crossing a block boundary.  Added a test cases covering this scenario. More details [here](https://crbug.com/1286003).