### PR TITLE
This patch fixes a link generation bug when selection has non text content on its edges.

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -154,6 +154,15 @@ const doGenerateFragment = (selection, startTime) => {
 
   expandRangeStartToWordBound(range);
   expandRangeEndToWordBound(range);
+  // Keep a copy of the range before we try to shrink it to make it start and
+  // end in text nodes. We need to use the range edges as starting points
+  // for context term building, so it makes sense to start from the original
+  // edges instead of the edges after shrinking. This way we don't have to
+  // traverse all the non-text nodes that are between the edges after shrinking
+  // and the original ones.
+  const rangeBeforeShrinking = range.cloneRange();
+
+  moveRangeEdgesToTextNodes(range);
 
   if (range.collapsed) {
     return {status: GenerateFragmentStatus.INVALID_SELECTION};
@@ -203,8 +212,10 @@ const doGenerateFragment = (selection, startTime) => {
   prefixRange.selectNodeContents(document.body);
   const suffixRange = prefixRange.cloneRange();
 
-  prefixRange.setEnd(range.startContainer, range.startOffset);
-  suffixRange.setStart(range.endContainer, range.endOffset);
+  prefixRange.setEnd(
+      rangeBeforeShrinking.startContainer, rangeBeforeShrinking.startOffset);
+  suffixRange.setStart(
+      rangeBeforeShrinking.endContainer, rangeBeforeShrinking.endOffset);
 
   const prefixSearchSpace = getSearchSpaceForEnd(prefixRange);
   const suffixSearchSpace = getSearchSpaceForStart(suffixRange);
@@ -1142,6 +1153,48 @@ const getLastNodeForBlockSearch = (range) => {
 };
 
 /**
+ * Finds the first visible text node within a given range.
+ * @param {Range} range - range in which to find the first visible text node
+ * @returns {Node} - first visible text node within |range| or null if there are
+ * no visible text nodes within |range|
+ */
+const getFirstTextNode = (range) => {
+  // Check if first node in the range is a visible text node.
+  const firstNode = getFirstNodeForBlockSearch(range);
+  if (isText(firstNode) && fragments.internal.isNodeVisible(firstNode)) {
+    return firstNode;
+  }
+
+  // First node is not visible text, use a tree walker to find the first visible
+  // text node.
+  const walker = fragments.internal.makeTextNodeWalker(range);
+  walker.currentNode = firstNode;
+
+  return walker.nextNode();
+};
+
+/**
+ * Finds the last visible text node within a given range.
+ * @param {Range} range - range in which to find the last visible text node
+ * @returns {Node} - last visible text node within |range| or null if there are
+ * no visible text nodes within |range|
+ */
+const getLastTextNode = (range) => {
+  // Check if last node in the range is a visible text node.
+  const lastNode = getLastNodeForBlockSearch(range);
+  if (isText(lastNode) && fragments.internal.isNodeVisible(lastNode)) {
+    return lastNode;
+  }
+
+  // Last node is not visible text, traverse the range backwards to find the
+  // last visible text node.
+  const walker = fragments.internal.makeTextNodeWalker(range);
+  walker.currentNode = lastNode;
+
+  return fragments.internal.backwardTraverse(walker, new Set());
+};
+
+/**
  * Determines whether or not a range crosses a block boundary.
  * @param {Range} range - the range to investigate
  * @return {boolean} - true if a block boundary was found,
@@ -1336,6 +1389,32 @@ const expandRangeStartToWordBound = (range) => {
       // this as an error.
       range.collapse();
     }
+  }
+};
+
+/**
+ * Moves the range edges to the first and last visible text nodes inside of it.
+ * @param {Range} range - the range to be modified
+ */
+const moveRangeEdgesToTextNodes = (range) => {
+  const firstNode = getFirstNodeForBlockSearch(range);
+  if (!isText(firstNode)) {
+    const firstTextNode = getFirstTextNode(range);
+    if (firstTextNode == null) {
+      range.collapse();
+      return;
+    }
+    range.setStart(firstTextNode, 0);
+  }
+
+  const lastNode = getLastNodeForBlockSearch(range);
+  if (!isText(lastNode)) {
+    const lastTextNode = getLastTextNode(range);
+    if (lastTextNode == null) {
+      range.collapse();
+      return;
+    }
+    range.setEnd(lastTextNode, lastTextNode.textContent.length);
   }
 };
 
@@ -1636,7 +1715,10 @@ export const forTesting = {
   getSearchSpaceForStart: getSearchSpaceForStart,
   getTextNodesInSameBlock: getTextNodesInSameBlock,
   recordStartTime: recordStartTime,
-  BlockTextAccumulator: BlockTextAccumulator
+  BlockTextAccumulator: BlockTextAccumulator,
+  getFirstTextNode: getFirstTextNode,
+  getLastTextNode: getLastTextNode,
+  moveRangeEdgesToTextNodes: moveRangeEdgesToTextNodes
 };
 
 // Allow importing module from closure-compiler projects that haven't migrated

--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1394,26 +1394,31 @@ const expandRangeStartToWordBound = (range) => {
 
 /**
  * Moves the range edges to the first and last visible text nodes inside of it.
+ * If there are no visible text nodes in the range then it is collapsed.
  * @param {Range} range - the range to be modified
  */
 const moveRangeEdgesToTextNodes = (range) => {
+  const firstTextNode = getFirstTextNode(range);
+  // No text nodes in range. Collapsing the range and early return.
+  if (firstTextNode == null) {
+    range.collapse();
+    return;
+  }
+
   const firstNode = getFirstNodeForBlockSearch(range);
-  if (!isText(firstNode)) {
-    const firstTextNode = getFirstTextNode(range);
-    if (firstTextNode == null) {
-      range.collapse();
-      return;
-    }
+
+  // Making sure the range starts with visible text. 
+  if (firstNode !== firstTextNode) {
     range.setStart(firstTextNode, 0);
   }
 
   const lastNode = getLastNodeForBlockSearch(range);
-  if (!isText(lastNode)) {
-    const lastTextNode = getLastTextNode(range);
-    if (lastTextNode == null) {
-      range.collapse();
-      return;
-    }
+  const lastTextNode = getLastTextNode(range);
+  // No need for no text node checks here because we know at there's at least
+  // firstTextNode in the range.
+
+  // Making sure the range ends with visible text.
+  if (lastNode !== lastTextNode) {
     range.setEnd(lastTextNode, lastTextNode.textContent.length);
   }
 };

--- a/test/fragment-generation-utils-test.js
+++ b/test/fragment-generation-utils-test.js
@@ -1041,6 +1041,55 @@ describe('FragmentGenerationUtils', function() {
            .toEqual(generationUtils.GenerateFragmentStatus.SUCCESS);
      });
 
+  it('Given selection that starts and ends in non text nodes\n' +
+         'When generateFragment is called\n' +
+         'Then the returned fragment targets the text within the selection',
+     function() {
+       document.body.innerHTML = __html__['no-text-after-block-boundary.html'];
+
+       const start = document.getElementById('1');
+       const end = document.getElementById('2');
+       const range = document.createRange();
+       range.setStartBefore(start);
+       range.setEndAfter(end);
+
+       const selection = window.getSelection();
+       selection.removeAllRanges();
+       selection.addRange(range);
+
+       const generatedFragment = generationUtils.generateFragment(selection);
+       const expectedFragment = {
+         status: generationUtils.GenerateFragmentStatus.SUCCESS,
+         fragment: {textStart: 'text'},
+       };
+
+       expect(generatedFragment).toEqual(expectedFragment);
+     });
+
+  it('Given selection does not include visible text\n' +
+         'When generateFragment is called\n' +
+         'Then INVALID_SELECTION is returned',
+     function() {
+       document.body.innerHTML = __html__['no-text-nodes-in-range.html'];
+
+       const start = document.getElementById('1');
+       const end = document.getElementById('2');
+       const range = document.createRange();
+       range.setStartBefore(start);
+       range.setEndAfter(end);
+
+       const selection = window.getSelection();
+       selection.removeAllRanges();
+       selection.addRange(range);
+
+       const generatedFragment = generationUtils.generateFragment(selection);
+       const expectedFragment = {
+         status: generationUtils.GenerateFragmentStatus.INVALID_SELECTION
+       };
+
+       expect(generatedFragment).toEqual(expectedFragment);
+     });
+
   // BlockTextAccumulator tests
   it('Given non empty text has been appended\n' +
          'and block node has been appended\n' +
@@ -1286,5 +1335,234 @@ describe('FragmentGenerationUtils', function() {
        generationUtils.forTesting.expandRangeEndToWordBound(range);
 
        expect(range).toEqual(expectedRange);
+     });
+
+  // getFirstTextNode tests.
+  it('Given range with no visible text nodes\n' +
+         'When getFirstNode is called\n' +
+         'Then null is returned',
+     function() {
+       document.body.innerHTML = __html__['get-first-text-node-tests.html'];
+
+       const startNode = document.getElementById('1');
+       const endNode = document.getElementById('2');
+
+       const range = document.createRange();
+       range.setStartBefore(startNode);
+       range.setEndAfter(endNode);
+
+       const firstTextNode = generationUtils.forTesting.getFirstTextNode(range);
+
+       expect(firstTextNode).toBeNull();
+     });
+
+  it('Given range composed of only one visible text node\n' +
+         'When getFirstNode is called\n' +
+         'Then the text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-first-text-node-tests.html'];
+
+       const textNode = document.getElementById('3').firstChild;
+
+       const range = document.createRange();
+       range.selectNodeContents(textNode)
+
+       const firstTextNode = generationUtils.forTesting.getFirstTextNode(range);
+
+       expect(firstTextNode).toBe(textNode);
+     });
+
+  it('Given range with first visible text node after first node\n' +
+         'When getFirstNode is called\n' +
+         'Then the first visible text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-first-text-node-tests.html'];
+
+       const spanNode = document.getElementById('4');
+
+       const range = document.createRange();
+       range.selectNode(spanNode)
+
+       const firstTextNode = generationUtils.forTesting.getFirstTextNode(range);
+
+       expect(firstTextNode).toBe(spanNode.firstChild);
+     });
+
+  it('Given range multiple visible text nodes \n' +
+         'When getFirstNode is called\n' +
+         'Then the first visible text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-first-text-node-tests.html'];
+
+       const spanNode = document.getElementById('5');
+
+       const range = document.createRange();
+       range.selectNode(spanNode)
+
+       const firstTextNode = generationUtils.forTesting.getFirstTextNode(range);
+
+       expect(firstTextNode).toBe(spanNode.firstChild);
+     });
+
+  it('Given range first visible text node at its end \n' +
+         'When getFirstNode is called\n' +
+         'Then the first visible text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-first-text-node-tests.html'];
+
+       const spanNode = document.getElementById('6');
+
+       const range = document.createRange();
+       range.selectNode(spanNode);
+       range.setEnd(
+           spanNode.firstChild, spanNode.firstChild.textContent.length);
+
+       const firstTextNode = generationUtils.forTesting.getFirstTextNode(range);
+
+       expect(firstTextNode).toBe(spanNode.firstChild);
+     });
+
+  // getLastTextNode tests.
+  it('Given range with no visible text nodes\n' +
+         'When getLastNode is called\n' +
+         'Then null is returned',
+     function() {
+       document.body.innerHTML = __html__['get-last-text-node-tests.html'];
+
+       const startNode = document.getElementById('1');
+       const endNode = document.getElementById('2');
+
+       const range = document.createRange();
+       range.setStartBefore(startNode);
+       range.setEndAfter(endNode);
+
+       const lastTextNode = generationUtils.forTesting.getLastTextNode(range);
+
+       expect(lastTextNode).toBeNull();
+     });
+
+  it('Given range composed of only one visible text node\n' +
+         'When getLastNode is called\n' +
+         'Then the text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-last-text-node-tests.html'];
+
+       const textNode = document.getElementById('3').firstChild;
+
+       const range = document.createRange();
+       range.selectNodeContents(textNode)
+
+       const lastTextNode = generationUtils.forTesting.getLastTextNode(range);
+
+       expect(lastTextNode).toBe(textNode);
+     });
+
+  it('Given range with last visible text node before last node\n' +
+         'When getLastNode is called\n' +
+         'Then the last visible text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-last-text-node-tests.html'];
+
+       const spanNode = document.getElementById('4');
+
+       const range = document.createRange();
+       range.selectNode(spanNode)
+
+       const lastTextNode = generationUtils.forTesting.getLastTextNode(range);
+
+       expect(lastTextNode).toBe(spanNode.firstChild);
+     });
+
+  it('Given range multiple visible text nodes \n' +
+         'When getLastNode is called\n' +
+         'Then the last visible text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-last-text-node-tests.html'];
+
+       const spanNode = document.getElementById('5');
+
+       const range = document.createRange();
+       range.selectNode(spanNode)
+
+       const lastTextNode = generationUtils.forTesting.getLastTextNode(range);
+
+       const expectedTextNode = document.getElementById('6').firstChild;
+       expect(lastTextNode).toBe(expectedTextNode);
+     });
+
+  it('Given range last visible text node at its start \n' +
+         'When getLastNode is called\n' +
+         'Then the last visible text node is returned',
+     function() {
+       document.body.innerHTML = __html__['get-last-text-node-tests.html'];
+
+       const spanNode = document.getElementById('6');
+
+       const range = document.createRange();
+       range.selectNode(spanNode);
+       range.setStart(spanNode.firstChild, 0);
+
+       const lastTextNode = generationUtils.forTesting.getLastTextNode(range);
+
+       expect(lastTextNode).toBe(spanNode.firstChild);
+     });
+
+  // moveRangeEdgesToTextNodes tests.
+  it('Given a range that does not include visible text\n' +
+         'When moveRangeEdgesToTextNodes is called\n' +
+         'Then the range is collapsed',
+     function() {
+       document.body.innerHTML = __html__['no-text-nodes-in-range.html'];
+
+       const start = document.getElementById('1');
+       const end = document.getElementById('2');
+       const range = document.createRange();
+       range.setStartBefore(start);
+       range.setEndAfter(end);
+
+       generationUtils.forTesting.moveRangeEdgesToTextNodes(range);
+
+       expect(range.collapsed).toBeTrue();
+     });
+
+  it('Given a range that includes visible text but not on the edges\n' +
+         'When moveRangeEdgesToTextNodes is called\n' +
+         'Then the range edges are at the start and end of the visible text',
+     function() {
+       document.body.innerHTML =
+           __html__['move-range-edges-to-text-tests.html'];
+
+       const div = document.getElementById('1');
+       const range = document.createRange();
+       range.selectNodeContents(div);
+
+       generationUtils.forTesting.moveRangeEdgesToTextNodes(range);
+
+       const textNode = document.getElementById('2').firstChild;
+       expect(range.startContainer).toBe(textNode);
+       expect(range.startOffset).toBe(0);
+       expect(range.endContainer).toBe(textNode);
+       expect(range.endOffset).toBe(textNode.textContent.length);
+     });
+
+  it('Given a range that includes visible text on the edges\n' +
+         'When moveRangeEdgesToTextNodes is called\n' +
+         'Then the range edges are not changed',
+     function() {
+       document.body.innerHTML =
+           __html__['move-range-edges-to-text-tests.html'];
+
+       const span = document.getElementById('3');
+       const range = document.createRange();
+       range.selectNodeContents(span);
+
+       const originalRange = range.cloneRange();
+
+       generationUtils.forTesting.moveRangeEdgesToTextNodes(range);
+
+       expect(range.startContainer).toBe(originalRange.startContainer);
+       expect(range.startOffset).toBe(originalRange.startOffset);
+       expect(range.endContainer).toBe(originalRange.endContainer);
+       expect(range.endOffset).toBe(originalRange.endOffset);
      });
 });

--- a/test/get-first-text-node-tests.html
+++ b/test/get-first-text-node-tests.html
@@ -1,0 +1,14 @@
+<!--Range without visible text nodes-->
+<img id="1" /><img id="2" />
+
+<!--Range composed of only one text node-->
+<span id="3">This text node is the whole range</span>
+
+<!--Range with visible text after the first node-->
+<span id="4">This text starts after the start of the range</span>
+
+<!--Range with multiple text nodes-->
+<span id="5">This is the first text <span>This is another text</span></span>
+
+<!--Range with text node at the end-->
+<span id="6">This text is the end of the range</span>

--- a/test/get-last-text-node-tests.html
+++ b/test/get-last-text-node-tests.html
@@ -1,0 +1,16 @@
+<!--Range without visible text nodes-->
+<img id="1" /><img id="2" />
+
+<!--Range composed of only one text node-->
+<span id="3">This text node is the whole range</span>
+
+<!--Range with visible text before the last node-->
+<span id="4">This text node appears before the end of the range</span>
+
+<!--Range with multiple text nodes-->
+<span id="5"
+  >This is the first text <span id="6">This is the last text</span></span
+>
+
+<!--Range with text node at the end-->
+<span id="7">This text is the end of the range</span>

--- a/test/move-range-edges-to-text-tests.html
+++ b/test/move-range-edges-to-text-tests.html
@@ -1,0 +1,5 @@
+<!--Range with visible text but not on the edges-->
+<div id="1"><span id="2">Text</span></div>
+
+<!--Range with visible text in the edges-->
+<span id="3">Text</span>

--- a/test/no-text-after-block-boundary.html
+++ b/test/no-text-after-block-boundary.html
@@ -1,0 +1,1 @@
+<div><img id="1" />text<br /><img id="2" /></div>


### PR DESCRIPTION
[Bug details](crbug.com/1289262)

Fix: Before trying to generate a matching fragment, if the selected
range doesn't start or end in visible text (e.g: an image), we move
the edges of the range to the first and last visible text inside
the original selection. This removes the unexpected behaviors occurring
when the selection had non text content on its edges.