### PR TITLE
Show underline on links in highlights

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -1025,7 +1025,12 @@ export const setDefaultTextFragmentsStyle = ({backgroundColor, color}) => {
   const defaultStyle = `.${TEXT_FRAGMENT_CSS_CLASS_NAME} {
     background-color: ${backgroundColor};
     color: ${color};
-  }`
+  }
+  
+  .${TEXT_FRAGMENT_CSS_CLASS_NAME} a, a .${TEXT_FRAGMENT_CSS_CLASS_NAME} {
+    text-decoration: underline;
+  }
+  `
   if (styles.length === 0) {
     document.head.insertAdjacentHTML(
         'beforeend', `<style type="text/css">${defaultStyle}</style>`);


### PR DESCRIPTION
Some pages (e.g., Wikipedia) only distinguish links by their text
color (i.e., no underline). When the text color is overridden by
setDefaultTextFragmentsStyle, these links are not distinguishable
from regular text, so users may tap them inadvertently. This patch
updates CSS to ensure an underline is always displayed on links in
this situation.