### PR TITLE
Fixed regression in processTextFragmentDirective

### DIFF
--- a/src/fragment-generation-utils.js
+++ b/src/fragment-generation-utils.js
@@ -1407,7 +1407,7 @@ const moveRangeEdgesToTextNodes = (range) => {
 
   const firstNode = getFirstNodeForBlockSearch(range);
 
-  // Making sure the range starts with visible text. 
+  // Making sure the range starts with visible text.
   if (firstNode !== firstTextNode) {
     range.setStart(firstTextNode, 0);
   }

--- a/test/ambiguous-match.html
+++ b/test/ambiguous-match.html
@@ -3,4 +3,5 @@
   prefix1 <i id="target1">target</i> suffix1 prefix2
   <i id="target2">target</i> suffix2 prefix1 <i id="target3">target</i> suffix2
   prefix2 <i id="target4">target</i> suffix1
+  <div>start start end suffix</div>
 </div>

--- a/test/text-fragment-utils-test.js
+++ b/test/text-fragment-utils-test.js
@@ -588,6 +588,9 @@ describe('TextFragmentUtils', function() {
     result = utils.processTextFragmentDirective(fragment);
     expect(result.length).toEqual(2);
 
+    fragment = utils.forTesting.parseTextFragmentDirective('start,end');
+    result = utils.processTextFragmentDirective(fragment);
+    expect(result.length).toEqual(2);
 
     // prefix, textStart, + textEnd
     fragment =
@@ -598,6 +601,10 @@ describe('TextFragmentUtils', function() {
     // textStart, textEnd, + suffix
     fragment =
         utils.forTesting.parseTextFragmentDirective('target,target,-suffix2');
+    result = utils.processTextFragmentDirective(fragment);
+    expect(result.length).toEqual(2);
+
+    fragment = utils.forTesting.parseTextFragmentDirective('start,end,-suffix');
     result = utils.processTextFragmentDirective(fragment);
     expect(result.length).toEqual(2);
 


### PR DESCRIPTION
Fixing regression I introduced in #114. This regression was preventing processTextFragmentDirective from finding multiple matches for a fragment when its start term occurred multiple times (in the DOM) before its end term. This bug would cause link generation to produce ambiguous fragments in some scenarios.

Added unit test checking the regression scenario.