### PR TITLE
Highlight first match when ambiguous

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "text-fragments-polyfill",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "clang-format": "^1.7.0",

--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -132,8 +132,11 @@ export const processFragmentDirectives =
               fragmentDirectivesOfType.map((fragmentDirectiveOfType) => {
                 const result = processTextFragmentDirective(
                     fragmentDirectiveOfType, documentToProcess);
-                if (result.length === 1)
+                if (result.length >= 1) {
+                  // Per spec, the first matching text on the page should be
+                  // highlighted when multiple segments match.
                   return markRange(result[0], documentToProcess);
+                }
                 return [];
               });
         }

--- a/test/unit/text-fragment-utils-test.js
+++ b/test/unit/text-fragment-utils-test.js
@@ -40,6 +40,20 @@ describe('TextFragmentUtils', function() {
         );
   });
 
+  // The word 'a' is an ambiguous match in this document. With no prefix or
+  // suffix, we should get the first instance.
+  it('highlights the first instance of an ambiguous match', function() {
+    document.body.innerHTML = window.__html__['complicated-layout.html'];
+    const directives = utils.getFragmentDirectives('#:~:text=a');
+    const parsedDirectives = utils.parseFragmentDirectives(directives);
+    const processedDirectives = utils.processFragmentDirectives(
+        parsedDirectives,
+        )['text'];
+    const marks = processedDirectives[0];
+    expect(marksArrayToString(marks)).toEqual('a');
+    expect(marks[0].parentElement.id).toEqual('root');
+  });
+
   it('works with range-based matches across block boundaries', function() {
     document.body.innerHTML = window.__html__['complicated-layout.html'];
     const directives = utils.getFragmentDirectives(


### PR DESCRIPTION
We've been too strict; according to the spec it is valid if a URL
could identify more than one chunk of text, we should highlight
the first instance.

Ref: https://wicg.github.io/scroll-to-text-fragment/#syntax