### PR TITLE
fix "too much recursion" when parsing large bundle

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -1083,7 +1083,7 @@ export const applyTargetTextStyle = () => {
   for (const style of styles) {
     const cssRules = style.innerHTML;
     const targetTextRules =
-        cssRules.match(/(\w*)::target-text\s*{\s*((.|\n)*?)\s*}/g);
+        cssRules.match(/::target-text\s*{\s*(?:(?:.|\n)*?)\s*}/g);
     if (!targetTextRules) continue;
 
     const markCss = targetTextRules.join('\n');


### PR DESCRIPTION
On large css bundle the regexp used in applyTargetTextStyle for parsing css makes firefox hang seconds then throws an "Uncaught InternalError: too much recursion". This fix optimize the regexp by removing useless capture group and replace usefull ones by non capturing group.