### PR TITLE
fix jsdoc types in text-fragment-utils.js

### DIFF
--- a/src/text-fragment-utils.js
+++ b/src/text-fragment-utils.js
@@ -155,7 +155,7 @@ export const processFragmentDirectives =
  *     fragments in.
  * @param {Element=} root - the root element where to extract and mark
  *     fragments in.
- * @return {Ranges[]} - Zero or more ranges within the document corresponding
+ * @return {Range[]} - Zero or more ranges within the document corresponding
  *     to the fragment. If the fragment corresponds to more than one location
  *     in the document (i.e., is ambiguous) then the first two matches will be
  *     returned (regardless of how many more matches there may be in the
@@ -344,7 +344,7 @@ const CheckSuffixResult = {
  *     |potentialMatch| will be considered.
  * @param {Document} documentToProcess - document where to extract and mark
  *     fragments in.
- * @return {CheckSuffixResult} - enum value indicating that potentialMatch
+ * @return {(typeof CheckSuffixResult)[keyof typeof CheckSuffixResult]} - enum value indicating that potentialMatch
  *     should be accepted, that the search should continue, or that the search
  *     should halt.
  */
@@ -606,9 +606,9 @@ const isNodeVisible =
  * Filter function for use with TreeWalkers. Rejects nodes that aren't in the
  * given range or aren't visible.
  * @param {Node} node - the Node to evaluate
- * @param {Range|Undefined} range - the range in which node must fall. Optional;
+ * @param {Range|undefined} range - the range in which node must fall. Optional;
  *     if null, the range check is skipped.
- * @return {NodeFilter} - FILTER_ACCEPT or FILTER_REJECT, to be passed along to
+ * @return {Number} - FILTER_ACCEPT or FILTER_REJECT, to be passed along to
  *     a TreeWalker.
  */
 const acceptNodeIfVisibleInRange = (node, range) => {
@@ -627,7 +627,7 @@ const acceptNodeIfVisibleInRange = (node, range) => {
  * @param {Node} node - the Node to evaluate
  * @param {Range} range - the range in which node must fall. Optional;
  *     if null, the range check is skipped/
- * @return {NodeFilter} - NodeFilter value to be passed along to a TreeWalker.
+ * @return {Number} - NodeFilter value to be passed along to a TreeWalker.
  * Values returned:
  *  - FILTER_REJECT: Node not in range or not visible.
  *  - FILTER_SKIP: Non Text Node visible and in range
@@ -649,7 +649,7 @@ const acceptTextNodeIfVisibleInRange = (node, range) => {
  * Extracts all the text nodes within the given range.
  * @param {Node} root - the root node in which to search
  * @param {Range} range - a range restricting the scope of extraction
- * @return {Array<String[]>} - a list of lists of text nodes, in document order.
+ * @return {Array<Text[]>} - a list of lists of text nodes, in document order.
  *     Lists represent block boundaries; i.e., two nodes appear in the same list
  *     iff there are no block element starts or ends in between them.
  */
@@ -735,7 +735,7 @@ function* getElementsIn(root, filter) {
  * Returns a range pointing to the first instance of |query| within |range|.
  * @param {String} query - the string to find
  * @param {Range} range - the range in which to search
- * @return {Range|Undefined} - The first found instance of |query| within
+ * @return {Range|undefined} - The first found instance of |query| within
  *     |range|.
  */
 const findTextInRange = (query, range) => {
@@ -757,7 +757,7 @@ const findTextInRange = (query, range) => {
  * @param {Node[]} textNodes - the visible text nodes within |range|
  * @param {Intl.Segmenter} [segmenter] - a segmenter to be used for finding word
  *     boundaries, if supported
- * @return {Range} - the found range, or undefined if no such range could be
+ * @return {Range|undefined} - the found range, or undefined if no such range could be
  *     found
  */
 const findRangeFromNodeList = (query, range, textNodes, segmenter) => {
@@ -811,7 +811,7 @@ const findRangeFromNodeList = (query, range, textNodes, segmenter) => {
  *     space
  * @param {bool} isEnd - indicates whether the offset is the start or end of the
  *     substring
- * @return {BoundaryPoint} - a boundary point suitable for setting as the start
+ * @return {BoundaryPoint|undefined} - a boundary point suitable for setting as the start
  *     or end of a Range, or undefined if it couldn't be computed.
  */
 const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
@@ -897,7 +897,7 @@ const getBoundaryPointAtIndex = (index, textNodes, isEnd) => {
  * @param {Number} length - the length of the substring
  * @param {Intl.Segmenter} [segmenter] - a segmenter to be used for finding word
  *     boundaries, if supported
- * @return {bool} - true iff startPos and length point to a word-bounded
+ * @return {boolean} - true iff startPos and length point to a word-bounded
  *     substring of |text|.
  */
 const isWordBounded = (text, startPos, length, segmenter) => {


### PR DESCRIPTION
Many people uses ts syntax for jsdoc annotation so I replaced enum type with ts-compatible annotations,  but still I guess they can be reverted.
Rest changes include typos and semantic mistakes.
